### PR TITLE
feat: add roslyn_debug_attach tool (DEBUG builds only)

### DIFF
--- a/src/RoslynMcp/Tools/DebugAttachTool.cs
+++ b/src/RoslynMcp/Tools/DebugAttachTool.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Tools;
+
+#if DEBUG
+[McpServerToolType]
+internal sealed class DebugAttachTool
+{
+	readonly FileLogger logger;
+
+	public DebugAttachTool(FileLogger logger) { this.logger = logger; }
+
+	[McpServerTool(Name = "roslyn_debug_attach", Destructive = false)]
+	[Description(
+		"DEBUG ONLY — do NOT call unless the user explicitly asks to attach a debugger. " +
+		"Launches the JIT debugger dialog so Visual Studio can attach to the running server process. " +
+		"The server pauses until a debugger attaches or the dialog is dismissed.")]
+	public object DebugAttach()
+	{
+		var pid = Environment.ProcessId;
+		logger.LogTool("roslyn_debug_attach", 0, true, $"launching debugger for PID {pid}");
+
+		if(Debugger.IsAttached)
+			return new { already_attached = true, pid, message = "A debugger is already attached." };
+
+		Debugger.Launch();
+
+		return new {
+			attached = Debugger.IsAttached,
+			pid,
+			message = Debugger.IsAttached
+				? "Debugger attached. Set breakpoints and invoke the next tool."
+				: "Debugger dialog was dismissed without attaching."
+		};
+	}
+}
+#endif


### PR DESCRIPTION
## Summary

- Adds `roslyn_debug_attach` — calls `Debugger.Launch()` to pop the VS JIT attach dialog mid-session
- `#if DEBUG` only, follows the same pattern as `roslyn_respawn`
- Description explicitly states "do NOT call unless the user explicitly asks to attach a debugger" to prevent agents from invoking it autonomously
- Reports whether a debugger was already attached, and whether attach succeeded

## Test plan

- [ ] Build in Debug, verify `roslyn_debug_attach` appears in tool list
- [ ] Build in Release, verify it does not appear
- [ ] Invoke the tool, confirm VS attach dialog appears
- [ ] Invoke when already attached, confirm `already_attached: true` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)