### PR TITLE
fix: register 5 invisible tools, fix pagination crash, fix AdhocWorkspace root path

### DIFF
--- a/src/RoslynMcp/Tools/Analysis/FileOutlineTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FileOutlineTool.cs
@@ -10,6 +10,10 @@ internal sealed class FileOutlineTool : RoslynMcpTool
 {
 	public FileOutlineTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
 	
+	[McpServerTool(Name = "roslyn_get_file_outline", ReadOnly = true)]
+	[Description(
+		"Returns a structured outline of a file: types and their members (signatures only, no bodies). " +
+		"Saves tokens by avoiding full file reads. Results are paged; use skip/take for large files.")]
 	public async Task<object> GetFileOutline(
 		[Description("Relative file path, e.g. 'Core/WindowTracker.cs'.")] string filePath,
 		[Description(ProjectPathDescription)] string projectPath,
@@ -35,7 +39,7 @@ internal sealed class FileOutlineTool : RoslynMcpTool
 		var root     = await tree.GetRootAsync();
 		var model    = compilation.GetSemanticModel(tree);
 		var allTypes = ExtractTypes(root, model);
-		var page     = allTypes.AsSpan(skip, Math.Min(take, allTypes.Length - skip));
+		var page     = Paginate(allTypes, ref skip, take);
 		
 		return scope.Outcome($"{page.Length}/{allTypes.Length} type(s)", new {
 			file        = Path.GetRelativePath(rootPath, tree.FilePath),

--- a/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
@@ -58,7 +58,7 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 						implementations = new[] { "No implementations found." }
 					};
 				
-				var page = allResults.AsSpan(skip, Math.Min(take, allResults.Length - skip)).ToArray();
+				var page = Paginate(allResults, ref skip, take);
 				
 				return scope.Outcome($"{page.Length}/{allResults.Length} implementation(s)", new {
 					symbol_type  = typeSymbol.TypeKind.ToString().ToLowerInvariant(),
@@ -99,7 +99,7 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 						overrides = new[] { "No overrides found." }
 					};
 				
-				var page = allResults.AsSpan(skip, Math.Min(take, allResults.Length - skip)).ToArray();
+				var page = Paginate(allResults, ref skip, take);
 				
 				return scope.Outcome($"{page.Length}/{allResults.Length} override(s)", new {
 					symbol_type = "method",

--- a/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
@@ -60,7 +60,7 @@ internal sealed class FindReferencesTool : RoslynMcpTool
 		if(allResults.Length == 0)
 			return new { total_references = 0, skip, take, references = new[] { $"No references found for '{symbolName}'." } };
 		
-		var page = allResults.AsSpan(skip, Math.Min(take, allResults.Length - skip)).ToArray();
+		var page = Paginate(allResults, ref skip, take);
 		
 		return scope.Outcome($"{page.Length}/{allResults.Length} reference(s)", new {
 			total_references = allResults.Length,

--- a/src/RoslynMcp/Tools/Analysis/GetLineCountTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetLineCountTool.cs
@@ -10,6 +10,9 @@ internal sealed class GetLineCountTool : RoslynMcpTool
 {
     public GetLineCountTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
 
+    [McpServerTool(Name = "roslyn_get_line_count", ReadOnly = true)]
+    [Description(
+        "Returns the line count for one or more files. Accepts a single path or comma-separated list.")]
     public async Task<object> GetLineCount(
 		[Description("Relative file path or comma-separated list of paths, e.g. 'WorkspaceManager.cs' or 'Foo.cs,Bar.cs,appsettings.json'.")] string filePaths,
 		[Description(ProjectPathDescription)] string projectPath)

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolsInScopeTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolsInScopeTool.cs
@@ -10,6 +10,10 @@ internal sealed class GetSymbolsInScopeTool : RoslynMcpTool
 {
 	public GetSymbolsInScopeTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
 	
+	[McpServerTool(Name = "roslyn_get_symbols_in_scope", ReadOnly = true)]
+	[Description(
+		"Returns all symbols accessible at a specific file location: locals, parameters, fields, properties, methods, types. " +
+		"Use when generating code to understand what's available in scope.")]
 	public async Task<object> GetSymbolsInScope(
 		[Description("Relative file path, e.g. 'Core/WindowTracker.cs'.")] string filePath,
 		[Description("1-based line number.")] int line,

--- a/src/RoslynMcp/Tools/Analysis/GetUsingsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetUsingsTool.cs
@@ -10,6 +10,9 @@ internal sealed class GetUsingsTool : RoslynMcpTool
 {
 	public GetUsingsTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
 	
+	[McpServerTool(Name = "roslyn_get_usings", ReadOnly = true)]
+	[Description(
+		"Returns all using directives in a file plus implicit global usings from the project.")]
 	public async Task<object> GetUsings(
 		[Description("Relative file path, e.g. 'Core/WindowTracker.cs'.")] string filePath,
 		[Description(ProjectPathDescription)] string projectPath)

--- a/src/RoslynMcp/Tools/Analysis/TypeHierarchyTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/TypeHierarchyTool.cs
@@ -51,7 +51,7 @@ internal sealed class TypeHierarchyTool : RoslynMcpTool
 		// Page both interfaces
 		var combined = allInterfaces.Concat(allDerived).ToArray()
 		;
-		var page     = combined.AsSpan(skip, Math.Min(take, combined.Length - skip)).ToArray();
+		var page     = Paginate(combined, ref skip, take);
 		
 		return scope.Outcome($"{page.Length} interface(s)/derived", new {
 			type_name           = type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),

--- a/src/RoslynMcp/Tools/Analysis/TypeMembersTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/TypeMembersTool.cs
@@ -46,7 +46,7 @@ internal sealed class TypeMembersTool : RoslynMcpTool
 				.Where(m => m is not null)
 		];
 		
-		var page = allMembers.AsSpan(skip, Math.Min(take, allMembers.Length - skip)).ToArray();
+		var page = Paginate(allMembers, ref skip, take);
 		
 		return scope.Outcome($"{page.Length}/{allMembers.Length} member(s)", new {
 			type_name = type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -319,6 +319,17 @@ internal abstract partial class RoslynMcpTool
 		"reduced functionality). Prefer passing the .csproj path directly for full MSBuild support.";
 
 	/// <summary>
+	///     Returns a safe page slice from an array. Clamps <paramref name="skip"/> to
+	///     <c>[0, items.Length]</c> so callers never hit <see cref="ArgumentOutOfRangeException"/>.
+	/// </summary>
+	protected static T[] Paginate<T>(T[] items, ref int skip, int take)
+	{
+		skip = Math.Clamp(skip, 0, items.Length);
+
+		return items.AsSpan(skip, Math.Min(take, items.Length - skip)).ToArray();
+	}
+
+	/// <summary>
 	///     Normalizes a file path for cross-platform compatibility by converting forward slashes
 	///     to the platform directory separator. Agents commonly supply Unix-style paths; this
 	///     ensures suffix matching against Roslyn's <see cref="SyntaxTree.FilePath"/> works on Windows.

--- a/src/RoslynMcp/Tools/Search/SearchFilesTool.cs
+++ b/src/RoslynMcp/Tools/Search/SearchFilesTool.cs
@@ -10,6 +10,11 @@ internal sealed class SearchFilesTool : RoslynMcpTool
 {
 	public SearchFilesTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
 	
+	[McpServerTool(Name = "roslyn_search_files", ReadOnly = true)]
+	[Description(
+		"Searches workspace files for lines matching a regex pattern. " +
+		"Returns file paths, line numbers, and matching text with paging support. " +
+		"Use this to discover code locations before applying Roslyn tools.")]
 	public object SearchFiles(
 		[Description("Regex pattern to search for (e.g., 'class.*Tool', 'TODO.*performance').")] string pattern,
 		[Description(ProjectPathDescription)] string projectPath,

--- a/src/RoslynMcp/Tools/Search/SearchFilesTool.cs
+++ b/src/RoslynMcp/Tools/Search/SearchFilesTool.cs
@@ -51,11 +51,12 @@ internal sealed class SearchFilesTool : RoslynMcpTool
 		var solution   = workspace.GetSolution(projectPath);
 		var rootPath   = workspace.GetRootPath(projectPath);
 		var allMatches = new List<MatchResult>();
-		
+		var seenPaths  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
 		foreach(var project in solution.Projects)
 			foreach(var document in project.Documents) {
-			
-				if(document.FilePath is null)
+
+				if(document.FilePath is null || !seenPaths.Add(document.FilePath))
 					continue;
 				
 				var fileName = Path.GetFileName(document.FilePath);

--- a/src/RoslynMcp/Tools/Search/SemanticSearchTool.cs
+++ b/src/RoslynMcp/Tools/Search/SemanticSearchTool.cs
@@ -89,11 +89,12 @@ internal sealed class SemanticSearchTool : RoslynMcpTool
 		var solution   = workspace.GetSolution(projectPath);
 		var rootPath   = workspace.GetRootPath(projectPath);
 		var allMatches = new List<SemanticMatchResult>();
-		
+		var seenPaths  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
 		foreach(var project in solution.Projects)
 			foreach(var document in project.Documents) {
-			
-				if(document.FilePath is null)
+
+				if(document.FilePath is null || !seenPaths.Add(document.FilePath))
 					continue;
 				
 				var fileName = Path.GetFileName(document.FilePath);

--- a/src/RoslynMcp/WorkspaceResolver.cs
+++ b/src/RoslynMcp/WorkspaceResolver.cs
@@ -61,8 +61,9 @@ internal sealed class WorkspaceResolver
 	{
 		var (resolved, _) = ResolveWithKind(projectPath);
 
-		// Root path is the directory containing the .csproj
-		return Path.GetDirectoryName(resolved)!;
+		return resolved.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
+			? Path.GetDirectoryName(resolved)!
+			: resolved;
 	}
 	
 	/// <summary>


### PR DESCRIPTION
## Summary

Three v0.4.0 bug fixes:

- **Fix 5 unregistered tools (#15)** — FileOutlineTool, GetSymbolsInScopeTool, GetUsingsTool, GetLineCountTool, SearchFilesTool were missing `[McpServerTool]` and `[Description]` attributes. 20% of tools were silently invisible to MCP clients.
- **Fix pagination crash (#16)** — `AsSpan(skip, ...)` threw `ArgumentOutOfRangeException` when `skip >= results.Length`. Added `Math.Clamp(skip, 0, array.Length)` before each `AsSpan` call in 5 tools.
- **Fix GetRootPath for AdhocWorkspaces (#17)** — `Path.GetDirectoryName` on a directory returns its parent. Now returns the directory itself when the resolved path is not a `.csproj`.

Fixes #15, Fixes #16, Fixes #17

## Test plan

- [ ] Verify the 5 previously invisible tools now appear in MCP tool list
- [ ] Call a paginated tool with `skip` larger than result count — should return empty page, not crash
- [ ] Call any tool against a directory without a `.csproj` — relative paths in output should be correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)