### PR TITLE
fix: SolutionDiff \r\n line splitting + correct MSBuildWorkspace comment

### DIFF
--- a/src/RoslynMcp/SolutionDiff.cs
+++ b/src/RoslynMcp/SolutionDiff.cs
@@ -61,8 +61,8 @@ internal static class SolutionDiff
 	
 	private static string BuildHunks(string oldText, string newText)
 	{
-		var oldLines = oldText.Split('\n');
-		var newLines = newText.Split('\n');
+		var oldLines = oldText.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+		var newLines = newText.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
 		var sb       = new System.Text.StringBuilder();
 		
 		// Simple greedy diff: find changed regions with 3-line context.

--- a/src/RoslynMcp/WorkspaceManager.cs
+++ b/src/RoslynMcp/WorkspaceManager.cs
@@ -396,7 +396,8 @@ internal sealed class WorkspaceManager : IDisposable
 			(workspace, projectId) = LoadMSBuildWorkspace(csprojPath);
 			isMSBuild = true;
 			
-			// MSBuildWorkspace watches files via Roslyn's internal mechanisms — no manual watcher needed.
+			// MSBuildWorkspace is a snapshot — it does NOT auto-detect file changes.
+			// External edits are picked up only when InvalidateFile is explicitly called by a tool.
 		}
 		
 		/// <summary>


### PR DESCRIPTION
## Summary

- **SolutionDiff \r\n splitting** — `Split('\n')` left trailing `\r` on every line of diff output on Windows. Now splits on `\r\n` and `\n`.
- **MSBuildWorkspace comment** — Corrected misleading comment that claimed MSBuildWorkspace watches files automatically. It's a snapshot workspace; changes are only reflected when `InvalidateFile` is explicitly called.

Fixes #19

## Test plan

- [ ] Run `roslyn_preview_rename` on Windows — verify diff output has no trailing `\r` on lines
- [ ] Verify the corrected comment in `WorkspaceManager.cs:399`

🤖 Generated with [Claude Code](https://claude.com/claude-code)