### PR TITLE
fix: add ResolveFilePath fallback for solution-root relative paths

### DIFF
--- a/src/RoslynMcp/Tools/Analysis/ReadFileTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ReadFileTool.cs
@@ -50,12 +50,9 @@ internal sealed class ReadFileTool : RoslynMcpTool
         else {
 
             // Non-.cs: fall back to disk.
-            var fullPath = Path.IsPathRooted(filePath)
-                ? filePath
-                : Path.GetFullPath(Path.Combine(rootPath, normalized))
-            ;
+            var fullPath = ResolveFilePath(filePath, rootPath);
 
-            if(!File.Exists(fullPath))
+            if(fullPath is null)
                 return scope.Failed("file not found", new { error = $"File not found: {filePath}" });
 
             sourceText    = SourceText.From(await File.ReadAllTextAsync(fullPath));

--- a/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
@@ -40,11 +40,9 @@ internal sealed class ReplaceInCodeTool : RoslynMcpTool
 		using var scope = BeginTool("roslyn_replace_in_code", filePath);
 		var rootPath = workspace.GetRootPath(projectPath);
 		
-		var fullPath = Path.IsPathRooted(filePath)
-			? filePath
-			: Path.GetFullPath(Path.Combine(rootPath, filePath));
-		
-		if(!File.Exists(fullPath))
+		var fullPath = ResolveFilePath(filePath, rootPath);
+
+		if(fullPath is null)
 			return scope.Failed("file not found", new { error = $"File not found: {filePath}" });
 		
 		if(!fullPath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))

--- a/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
@@ -33,11 +33,9 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 	{
 		using var scope = BeginTool("roslyn_replace_in_file", filePath);
 		var rootPath = workspace.GetRootPath(projectPath);
-		var fullPath = Path.IsPathRooted(filePath)
-			? filePath
-			: Path.GetFullPath(Path.Combine(rootPath, filePath));
-		
-		if(!File.Exists(fullPath))
+		var fullPath = ResolveFilePath(filePath, rootPath);
+
+		if(fullPath is null)
 			return scope.Failed("file not found", new { error = $"File not found: {filePath}" });
 		
 		Regex regex;

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -330,6 +330,40 @@ internal abstract partial class RoslynMcpTool
 	}
 
 	/// <summary>
+	///     Resolves a relative file path to a full path. Tries <paramref name="rootPath"/> first;
+	///     if the file isn't found there, walks subdirectories looking for a suffix match.
+	///     Returns null if the file can't be found.
+	/// </summary>
+	protected static string? ResolveFilePath(string filePath, string rootPath)
+	{
+		if(Path.IsPathRooted(filePath))
+			return File.Exists(filePath) ? filePath : null;
+
+		var normalized = NormalizePath(filePath);
+		var direct     = Path.GetFullPath(Path.Combine(rootPath, normalized));
+
+		if(File.Exists(direct))
+			return direct;
+
+		// Fallback: suffix match — handles agents passing project-relative paths
+		// when rootPath is the solution directory.
+		var suffix = Path.DirectorySeparatorChar + normalized;
+
+		try {
+
+			foreach(var candidate in Directory.EnumerateFiles(rootPath, Path.GetFileName(normalized), SearchOption.AllDirectories)) {
+
+				if(candidate.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+					|| string.Equals(Path.GetFileName(candidate), Path.GetFileName(normalized), StringComparison.OrdinalIgnoreCase))
+					return candidate;
+			}
+		}
+		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) { }
+
+		return null;
+	}
+
+	/// <summary>
 	///     Normalizes a file path for cross-platform compatibility by converting forward slashes
 	///     to the platform directory separator. Agents commonly supply Unix-style paths; this
 	///     ensures suffix matching against Roslyn's <see cref="SyntaxTree.FilePath"/> works on Windows.


### PR DESCRIPTION
## Summary

With solution-level loading (PR #42), `GetRootPath` returns the solution directory instead of the project directory. This broke tools that resolve `filePath` relative to `rootPath` when agents pass project-relative paths like `RoslynMcp.csproj` or `.test_temp.cs`.

- Add `ResolveFilePath` helper to `RoslynMcpTool` — tries `rootPath` first, falls back to suffix-matching via `Directory.EnumerateFiles`
- Wire into `ReadFileTool`, `ReplaceInFileTool`, `ReplaceInCodeTool`
- Preserves backward compat — agents don't need to change their path conventions

**Test harness: 27/27 passing** (was 21/27 before this fix).

## Test plan

- [x] Full test harness passes (27/27)
- [ ] Verify agents using project-relative paths still work after solution refactor
- [ ] Verify absolute paths still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)