### PR TITLE
fix: workspace infrastructure — cacheLock contention, volatile, FSW feedback loop

### DIFF
--- a/docs/plans/code-audit.md
+++ b/docs/plans/code-audit.md
@@ -296,3 +296,15 @@ The regex is applied to each **individual token's** text. A search for `"new Lis
 **File:** `ApprovalStore.cs:12`
 
 Each `PendingOperation` holds a full `Solution` snapshot. Unclaimed previews accumulate without bound. Long-running sessions with many previews could consume significant memory.
+
+---
+
+### 24. FSW feedback loop: `TryApplyChanges` writes trigger re-detection
+
+**File:** `WorkspaceManager.Instance.cs` (FlushMSBuild)
+
+`MSBuildWorkspace.TryApplyChanges(WithDocumentText)` writes the updated text back to the file on disk. This triggers the FileSystemWatcher's `Changed` event, creating an infinite cycle throttled only by the 300ms debounce. Each cycle writes the same content but triggers another event.
+
+**Fix (v0.6.0):** Suppress FSW events during `TryApplyChanges` via `watcher.EnableRaisingEvents = false/true`.
+
+**Future consideration:** Self-write tracking — track paths written by `TryApplyChanges` and skip FSW events for those paths within a short window. More precise, no lost events. See [Issue #49](https://github.com/MadQ/RoslynMcp/issues/49).

--- a/src/RoslynMcp/WorkspaceManager.Instance.cs
+++ b/src/RoslynMcp/WorkspaceManager.Instance.cs
@@ -210,12 +210,12 @@ internal sealed partial class WorkspaceManager
 						foreach(var id in docIds)
 							newSolution = newSolution.WithDocumentText(id, newText);
 
-						workspace.TryApplyChanges(newSolution);
+						ApplyChangesWithFswSuppressed(newSolution);
 					}
 					catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) { }
 				}
-
-				InvalidateCompilation();
+				else
+					InvalidateCompilation();
 			}
 			else if(workspace is AdhocWorkspace adhoc) {
 
@@ -395,6 +395,29 @@ internal sealed partial class WorkspaceManager
 
 		// ── FileSystemWatcher ────────────────────────────────────────────────
 
+		/// <summary>
+		///     Applies solution changes with FSW suppressed to prevent a feedback loop.
+		///     MSBuildWorkspace.TryApplyChanges writes text back to disk, which would
+		///     re-trigger the FSW. See issue #49.
+		/// </summary>
+		void ApplyChangesWithFswSuppressed(Solution newSolution)
+		{
+			if(watcher is not null)
+				watcher.EnableRaisingEvents = false;
+
+			try {
+
+				workspace.TryApplyChanges(newSolution);
+			}
+			finally {
+
+				if(watcher is not null)
+					watcher.EnableRaisingEvents = true;
+			}
+
+			InvalidateCompilation();
+		}
+
 		void StartWatcher()
 		{
 			watcher = new FileSystemWatcher(rootPath, "*.cs")
@@ -498,11 +521,8 @@ internal sealed partial class WorkspaceManager
 				catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) { }
 			}
 
-			if(modified) {
-
-				workspace.TryApplyChanges(newSolution);
-				InvalidateCompilation();
-			}
+			if(modified)
+				ApplyChangesWithFswSuppressed(newSolution);
 		}
 
 		void FlushAdhoc(AdhocWorkspace adhoc, string[] changed, string[] deleted)

--- a/src/RoslynMcp/WorkspaceManager.cs
+++ b/src/RoslynMcp/WorkspaceManager.cs
@@ -38,7 +38,9 @@ internal sealed partial class WorkspaceManager : IDisposable
 	readonly int    maxCachedWorkspaces;
 
 	// Deferred MSBuild registration — only attempted on first MSBuildWorkspace use.
-	static bool           msbuildRegistered;
+	// volatile: read outside lock in double-checked pattern; .NET memory model (ECMA-335)
+	// doesn't guarantee visibility on ARM without it. See CONTRIBUTING.md "Right Code Principle".
+	static volatile bool  msbuildRegistered;
 	static readonly object msbuildLock = new();
 
 	public WorkspaceManager()
@@ -61,9 +63,9 @@ internal sealed partial class WorkspaceManager : IDisposable
 	{
 		var normalizedPath = Path.GetFullPath(resolvedPath);
 
+		// Fast path: cache hit under short lock — doesn't block on workspace loading.
 		lock(cacheLock) {
 
-			// Check secondary index (handles .csproj → solution mapping).
 			if(projectToCacheKey.TryGetValue(normalizedPath, out var mappedKey)
 				&& cache.TryGetValue(mappedKey, out var mappedEntry)) {
 
@@ -76,41 +78,59 @@ internal sealed partial class WorkspaceManager : IDisposable
 				cache[normalizedPath] = entry with { LastAccess = DateTime.UtcNow };
 				return entry.Instance;
 			}
+		}
 
-			WorkspaceInstance instance;
-			string cacheKey;
+		// Slow path: load outside lock so other tool calls can still hit the cache.
+		WorkspaceInstance instance;
+		string cacheKey;
 
-			if(normalizedPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)) {
+		if(normalizedPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)) {
 
-				var solutionPath = FindSolutionFileUpwards(Path.GetDirectoryName(normalizedPath)!);
+			var solutionPath = FindSolutionFileUpwards(Path.GetDirectoryName(normalizedPath)!);
 
-				if(solutionPath is not null) {
+			if(solutionPath is not null) {
 
-					instance = WorkspaceInstance.ForSolution(solutionPath);
-					cacheKey = Path.GetFullPath(solutionPath);
-				}
-				else {
-
-					instance = WorkspaceInstance.ForProject(normalizedPath);
-					cacheKey = normalizedPath;
-				}
-
-				// Map all project paths to this cache key for future lookups.
-				foreach(var csproj in instance.ProjectPaths)
-					projectToCacheKey[csproj] = cacheKey;
+				instance = WorkspaceInstance.ForSolution(solutionPath);
+				cacheKey = Path.GetFullPath(solutionPath);
 			}
 			else {
 
-				instance = WorkspaceInstance.ForDirectory(normalizedPath);
+				instance = WorkspaceInstance.ForProject(normalizedPath);
 				cacheKey = normalizedPath;
 			}
+		}
+		else {
+
+			instance = WorkspaceInstance.ForDirectory(normalizedPath);
+			cacheKey = normalizedPath;
+		}
+
+		// Re-acquire lock to insert. Another thread may have loaded the same workspace.
+		lock(cacheLock) {
+
+			if(projectToCacheKey.TryGetValue(normalizedPath, out var raceKey)
+				&& cache.TryGetValue(raceKey, out var raceEntry)) {
+
+				instance.Dispose();
+				cache[raceKey] = raceEntry with { LastAccess = DateTime.UtcNow };
+				return raceEntry.Instance;
+			}
+
+			if(cache.TryGetValue(cacheKey, out var existing)) {
+
+				instance.Dispose();
+				cache[cacheKey] = existing with { LastAccess = DateTime.UtcNow };
+				return existing.Instance;
+			}
+
+			foreach(var csproj in instance.ProjectPaths)
+				projectToCacheKey[csproj] = cacheKey;
 
 			if(cache.Count >= maxCachedWorkspaces) {
 
 				var lru = cache.OrderBy(kvp => kvp.Value.LastAccess).First();
 				cache.Remove(lru.Key);
 
-				// Clean secondary index entries pointing to evicted workspace.
 				var staleKeys = projectToCacheKey
 					.Where(kvp => string.Equals(kvp.Value, lru.Key, StringComparison.OrdinalIgnoreCase))
 					.Select(kvp => kvp.Key)


### PR DESCRIPTION
## Summary

Three fixes for the workspace infrastructure layer:

- **cacheLock contention (#25)**: Workspace loading (multi-second MSBuild) no longer holds the cache lock. Other tool calls can still hit cached workspaces during loading. Double-checked pattern handles the race where two threads load the same workspace concurrently.

- **msbuildRegistered volatile (#25)**: Double-checked locking read outside lock needs `volatile` for correctness on ARM. Comment references CONTRIBUTING.md "Right Code Principle" — `volatile` is the right tool here despite general advice against it.

- **FSW feedback loop (#49)**: `MSBuildWorkspace.TryApplyChanges` writes text back to disk, re-triggering the FSW in an infinite cycle. New `ApplyChangesWithFswSuppressed` method disables FSW during writes. Applied in both `InvalidateFile` (tool-driven) and `FlushMSBuild` (FSW-driven). Documented as audit item #24.

Fixes #25, Fixes #49

## Test plan

- [x] 27/27 test harness passing
- [ ] Verify FSW create/modify/delete cycle works without feedback loop
- [ ] Verify concurrent tool calls don't deadlock during workspace loading
- [ ] Verify `volatile` comment is accurate and references the right doc section

🤖 Generated with [Claude Code](https://claude.com/claude-code)