### PR TITLE
feat: token-based pagination cache for all paginated tools

### DIFF
--- a/docs/plans/pagination-cache.md
+++ b/docs/plans/pagination-cache.md
@@ -1,0 +1,89 @@
+# Token-Based Pagination Cache
+
+**Issue:** [#40](https://github.com/MadQ/RoslynMcp/issues/40)
+**Status:** Implemented (PR #55)
+
+## Problem
+
+Every paginated tool re-executes its full query on each call. An agent paging through 200 references makes 4 identical `FindReferencesAsync` calls, discarding progressively more results each time.
+
+## Design: Token-Based Caching
+
+Instead of parameter hashing, use explicit tokens — the same pattern agents already understand from `roslyn_preview_rename` → `roslyn_apply_rename`.
+
+### How It Works
+
+**First call** (no `page_token`):
+```
+Agent: roslyn_find_references(symbolName: "Foo", projectPath: "...", take: 50)
+Server: { references: [...50], total: 200, page_token: "abc123", has_more: true }
+```
+
+**Subsequent call** (with `page_token`):
+```
+Agent: roslyn_find_references(page_token: "abc123", skip: 50, take: 50)
+Server: { items: [...50], total: 200, page_token: "abc123", has_more: true }
+```
+
+Note: subsequent-page responses use a standardized shape (`items`/`total`/`page_token`/`has_more`). Tool-specific metadata (symbol_type, _caution, etc.) is only in the first-page response — the agent already has that context.
+
+### Why Tokens Over Parameter Hashing
+
+- **No ambiguity** about what constitutes "the same query" — the token IS the identity
+- **No hash collisions** — each query gets a unique token
+- **Agents already understand tokens** from the rename workflow
+- **Simpler for agents** — pass token back instead of calculating skip values
+- **Zero breaking changes** — `skip`/`take` still work without token; token is purely additive
+
+### Components
+
+**`PaginationCache`** — DI singleton, similar to `ApprovalStore`:
+- `Store<T>(T[] items)` → returns token string (cache owns the array from this point)
+- `TryGet<T>(string token, out ReadOnlyMemory<T> items)` → returns cached results as `ReadOnlyMemory<T>` to prevent mutation of cached data
+- `InvalidateAll()` → clears on workspace changes
+- Sliding-window TTL (60s, reset on each access so active paging stays alive)
+- Capped at 50 entries, LRU eviction
+
+**`RoslynMcpTool` base class helpers:**
+- `TryServeCachedPage<T>(scope, pageToken, ref skip, take)` → one-line cache-hit path; returns standardized response or null on miss
+- `PaginateAndStore<T>(allResults, ref skip, take)` → cache-miss path; stores results and returns `PaginatedResult<T>` with token
+- `Paginate<T>(ReadOnlyMemory<T>, ref skip, take)` → zero-copy slice overload for cache hits
+
+**Invalidation:**
+- `WorkspaceResolver.InvalidateFile` calls `PaginationCache.InvalidateAll()`
+- Sliding TTL provides natural expiry for FSW-triggered changes
+- Editing tools trigger explicit invalidation via `InvalidateFile`
+
+### Memory Safety
+
+Cached arrays are returned as `ReadOnlyMemory<T>` — callers can slice but not mutate. The array is owned by the cache from the moment `Store` is called. `Paginate` creates a new `T[]` for the page slice via `.ToArray()`, so the cached data is never exposed directly.
+
+### Wired Tools
+
+| Tool | Status |
+|------|--------|
+| `find_references` | ✅ `page_token` parameter + cache |
+| `find_implementations` | ✅ `page_token` parameter + cache |
+| `type_hierarchy` | ✅ `page_token` parameter + cache |
+| `type_members` | ✅ `page_token` parameter + cache |
+| `file_outline` | ✅ `page_token` parameter + cache |
+| `search_files` | ✅ `page_token` parameter + cache |
+| `semantic_search` | ✅ `page_token` parameter + cache |
+| `list_files` | Needs `skip` parameter first |
+| `get_trivia` | Needs `skip` parameter first |
+| `list_types` | Needs `skip`/`take` parameters first |
+
+### Token Lifecycle
+
+1. Generated on first query (12-char hex, same as rename tokens)
+2. Valid for 60 seconds from last access (sliding window)
+3. Can be reused for multiple page requests within the TTL
+4. Expired tokens → cache miss → tool re-executes the query (no error)
+5. Max 50 cached result sets; oldest evicted when full
+6. All tokens invalidated when any file is edited via `InvalidateFile`
+
+### Test Coverage
+
+TestHarness includes 2 dedicated pagination tests (29/29 total):
+- Page 1: small `take`, verify `page_token` + `has_more: true`
+- Page 2: pass `page_token`, verify items served from cache with same token

--- a/src/RoslynMcp/PaginationCache.cs
+++ b/src/RoslynMcp/PaginationCache.cs
@@ -1,0 +1,76 @@
+namespace RoslynMcp;
+
+/// <summary>
+///     Caches paginated query results keyed by token. Agents pass the token back
+///     to get subsequent pages without re-executing the query. Sliding-window TTL
+///     resets on each access so active paging sessions stay alive.
+///     See docs/plans/pagination-cache.md for design.
+/// </summary>
+internal sealed class PaginationCache
+{
+	record CachedResult(Array Items, DateTime LastAccess);
+
+	private readonly Dictionary<string, CachedResult> cache = new();
+	private readonly object syncRoot = new();
+
+	private const int              MaxEntries = 50;
+	private static readonly TimeSpan Ttl      = TimeSpan.FromSeconds(60);
+
+	public string Store<T>(T[] items)
+	{
+		var token = Guid.NewGuid().ToString("N")[..12];
+
+		lock(syncRoot) {
+
+			EvictExpired();
+
+			while(cache.Count >= MaxEntries) {
+
+				var oldest = cache.OrderBy(kvp => kvp.Value.LastAccess).First();
+				cache.Remove(oldest.Key);
+			}
+
+			cache[token] = new CachedResult(items, DateTime.UtcNow);
+		}
+
+		return token;
+	}
+
+	public bool TryGet<T>(string token, out ReadOnlyMemory<T> items)
+	{
+		lock(syncRoot) {
+
+			if(cache.TryGetValue(token, out var entry)
+				&& DateTime.UtcNow - entry.LastAccess < Ttl
+				&& entry.Items is T[] typed) {
+
+				// Sliding window: reset TTL on each access.
+				cache[token] = entry with { LastAccess = DateTime.UtcNow };
+				items = typed.AsMemory();
+				return true;
+			}
+
+			items = ReadOnlyMemory<T>.Empty;
+			return false;
+		}
+	}
+
+	public void InvalidateAll()
+	{
+		lock(syncRoot)
+			cache.Clear();
+	}
+
+	void EvictExpired()
+	{
+		var now     = DateTime.UtcNow;
+		var expired = cache
+			.Where(kvp => now - kvp.Value.LastAccess >= Ttl)
+			.Select(kvp => kvp.Key)
+			.ToArray()
+		;
+
+		foreach(var key in expired)
+			cache.Remove(key);
+	}
+}

--- a/src/RoslynMcp/Program.cs
+++ b/src/RoslynMcp/Program.cs
@@ -47,6 +47,7 @@ builder.Services
 	.AddSingleton<WorkspaceManager>()
 	.AddSingleton<WorkspaceResolver>()
 	.AddSingleton<ApprovalStore>()
+	.AddSingleton<PaginationCache>()
 	.AddSingleton<FileLogger>()
 	.AddMcpServer()
 	.WithStdioServerTransport()

--- a/src/RoslynMcp/Tools/Analysis/DiagnosticsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/DiagnosticsTool.cs
@@ -8,7 +8,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class DiagnosticsTool : RoslynMcpTool
 {
-	public DiagnosticsTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public DiagnosticsTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_get_diagnostics", ReadOnly = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Analysis/FileOutlineTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FileOutlineTool.cs
@@ -8,7 +8,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class FileOutlineTool : RoslynMcpTool
 {
-	public FileOutlineTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public FileOutlineTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_get_file_outline", ReadOnly = true)]
 	[Description(
@@ -18,13 +18,19 @@ internal sealed class FileOutlineTool : RoslynMcpTool
 		[Description("Relative file path, e.g. 'Core/WindowTracker.cs'.")] string filePath,
 		[Description(ProjectPathDescription)] string projectPath,
 		[Description("Number of types to skip (for paging). Default: 0.")] int skip = 0,
-		[Description("Maximum number of types to return. Default: 20, max: 100.")] int take = 20)
+		[Description("Maximum number of types to return. Default: 20, max: 100.")] int take = 20,
+		[Description("Token from a previous response to get the next page without re-executing the query.")] string? page_token = null)
 	{
 		using var scope = BeginTool("roslyn_get_file_outline", filePath);
+
+		take = Math.Clamp(take, 1, 100);
+
+		var cachedPage = TryServeCachedPage<object>(scope, page_token, ref skip, take);
+		if(cachedPage is not null)
+			return cachedPage;
+
 		if(!TryGetCompilation(projectPath, out var compilation, out var error))
 			return error;
-		
-		take = Math.Clamp(take, 1, 100);
 		
 		var rootPath   = workspace.GetRootPath(projectPath);
 		var normalized = NormalizePath(filePath);
@@ -39,15 +45,16 @@ internal sealed class FileOutlineTool : RoslynMcpTool
 		var root     = await tree.GetRootAsync();
 		var model    = compilation.GetSemanticModel(tree);
 		var allTypes = ExtractTypes(root, model);
-		var page     = Paginate(allTypes, ref skip, take);
-		
-		return scope.Outcome($"{page.Length}/{allTypes.Length} type(s)", new {
+		var result   = PaginateAndStore(allTypes, ref skip, take);
+
+		return scope.Outcome($"{result.Items.Length}/{result.Total} type(s)", new {
 			file        = Path.GetRelativePath(rootPath, tree.FilePath),
-			total_types = allTypes.Length,
-			skip,
-			take,
-			types       = page.ToArray(),
-			_caution    = AdhocCaution(projectPath)
+			total_types = result.Total,
+			skip, take,
+			types      = result.Items,
+			page_token = result.PageToken,
+			has_more   = result.HasMore,
+			_caution   = AdhocCaution(projectPath)
 		});
 	}
 	

--- a/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class FindImplementationsTool : RoslynMcpTool
 {
-	public FindImplementationsTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public FindImplementationsTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_find_implementations", ReadOnly = true)]
 	[Description(
@@ -20,9 +20,17 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 		[Description(ProjectPathDescription)] string projectPath,
 		[Description("Optional containing type to narrow the search, e.g. 'SymbolVisitor' when searching for 'Accept'.")] string? containingType = null,
 		[Description("Number of implementations to skip (for paging). Default: 0.")] int skip = 0,
-		[Description("Maximum number of implementations to return. Default: 50, max: 200.")] int take = 50)
+		[Description("Maximum number of implementations to return. Default: 50, max: 200.")] int take = 50,
+		[Description("Token from a previous response to get the next page without re-executing the query.")] string? page_token = null)
 	{
 		using var scope = BeginTool("roslyn_find_implementations", symbolName);
+
+		take = Math.Clamp(take, 1, 200);
+
+		var cachedPage = TryServeCachedPage<string>(scope, page_token, ref skip, take);
+		if(cachedPage is not null)
+			return cachedPage;
+
 		if(!TryGetCompilation(projectPath, out var compilation, out var error))
 			return error;
 		
@@ -38,9 +46,7 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 		
 			if(typeSymbol.TypeKind is TypeKind.Interface or TypeKind.Class && typeSymbol.IsAbstract) {
 			
-				take = Math.Clamp(take, 1, 200);
-				
-				var impls = await RoslynSymbolFinder.FindImplementationsAsync(typeSymbol, solution);
+					var impls = await RoslynSymbolFinder.FindImplementationsAsync(typeSymbol, solution);
 				var allResults = impls
 					.OfType<INamedTypeSymbol>()
 					.Select(t => t.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat))
@@ -58,15 +64,16 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 						implementations = new[] { "No implementations found." }
 					};
 				
-				var page = Paginate(allResults, ref skip, take);
-				
-				return scope.Outcome($"{page.Length}/{allResults.Length} implementation(s)", new {
+				var result = PaginateAndStore(allResults, ref skip, take);
+
+				return scope.Outcome($"{result.Items.Length}/{result.Total} implementation(s)", new {
 					symbol_type  = typeSymbol.TypeKind.ToString().ToLowerInvariant(),
 					symbol_name  = typeSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-					total_implementations = allResults.Length,
-					skip,
-					take,
-					implementations = page,
+					total_implementations = result.Total,
+					skip, take,
+					implementations = result.Items,
+					page_token      = result.PageToken,
+					has_more        = result.HasMore,
 					_caution        = AdhocCaution(projectPath)
 				});
 			}
@@ -79,9 +86,7 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 		
 			if(methodSymbol.IsAbstract || methodSymbol.IsVirtual || methodSymbol.IsOverride) {
 			
-				take = Math.Clamp(take, 1, 200);
-				
-				var overrides = await RoslynSymbolFinder.FindOverridesAsync(methodSymbol, solution);
+					var overrides = await RoslynSymbolFinder.FindOverridesAsync(methodSymbol, solution);
 				var allResults = overrides
 					.OfType<IMethodSymbol>()
 					.Select(m => FormatMethod(m))
@@ -99,15 +104,16 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 						overrides = new[] { "No overrides found." }
 					};
 				
-				var page = Paginate(allResults, ref skip, take);
-				
-				return scope.Outcome($"{page.Length}/{allResults.Length} override(s)", new {
+				var result = PaginateAndStore(allResults, ref skip, take);
+
+				return scope.Outcome($"{result.Items.Length}/{result.Total} override(s)", new {
 					symbol_type = "method",
 					symbol_name = FormatMethod(methodSymbol),
-					total_overrides = allResults.Length,
-					skip,
-					take,
-					overrides = page,
+					total_overrides = result.Total,
+					skip, take,
+					overrides  = result.Items,
+					page_token = result.PageToken,
+					has_more   = result.HasMore,
 					_caution  = AdhocCaution(projectPath)
 				});
 			}

--- a/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class FindReferencesTool : RoslynMcpTool
 {
-	public FindReferencesTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public FindReferencesTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_find_references", ReadOnly = true)]
 	[Description(
@@ -20,52 +20,57 @@ internal sealed class FindReferencesTool : RoslynMcpTool
 		[Description(ProjectPathDescription)] string projectPath,
 		[Description("Optional type name to narrow the search, e.g. 'WindowTracker'.")] string? containingType = null,
 		[Description("Number of references to skip (for paging). Default: 0.")] int skip = 0,
-		[Description("Maximum number of references to return. Default: 50, max: 200.")] int take = 50)
+		[Description("Maximum number of references to return. Default: 50, max: 200.")] int take = 50,
+		[Description("Token from a previous response to get the next page without re-executing the query.")] string? page_token = null)
 	{
 		using var scope = BeginTool("roslyn_find_references", symbolName);
+
+		take = Math.Clamp(take, 1, 200);
+
+		var cachedPage = TryServeCachedPage<string>(scope, page_token, ref skip, take);
+		if(cachedPage is not null)
+			return cachedPage;
+
 		if(!TryGetCompilation(projectPath, out var compilation, out var error))
 			return error;
-		
-		take = Math.Clamp(take, 1, 200);
-		
-		var solution    = workspace.GetSolution(projectPath);
-		var rootPath    = workspace.GetRootPath(projectPath);
-		
-		var symbol = FindSymbol(compilation, symbolName, containingType);
-		
+
+		var solution = workspace.GetSolution(projectPath);
+		var rootPath = workspace.GetRootPath(projectPath);
+		var symbol   = FindSymbol(compilation, symbolName, containingType);
+
 		if(symbol is null)
 			return scope.Failed("symbol not found", new { error = $"Symbol '{symbolName}' not found." });
-		
+
 		var refs = await RoslynSymbolFinder.FindReferencesAsync(symbol, solution);
-		
+
 		var allResults = refs
 			.SelectMany(r => r.Locations)
 			.OrderBy(l => l.Location.SourceTree?.FilePath)
 			.ThenBy(l => l.Location.GetLineSpan().StartLinePosition.Line)
 			.Select(l => {
+
 				var span = l.Location.GetLineSpan();
 				var file = span.Path is { Length: > 0 } p
 					? Path.GetRelativePath(rootPath, p)
 					: "?";
-				
-				var line = span.StartLinePosition.Line + 1;
-				
-				return $"{file}:{line}";
+
+				return $"{file}:{span.StartLinePosition.Line + 1}";
 			})
 			.Distinct()
 			.ToArray()
 		;
-		
+
 		if(allResults.Length == 0)
 			return new { total_references = 0, skip, take, references = new[] { $"No references found for '{symbolName}'." } };
-		
-		var page = Paginate(allResults, ref skip, take);
-		
-		return scope.Outcome($"{page.Length}/{allResults.Length} reference(s)", new {
-			total_references = allResults.Length,
-			skip,
-			take,
-			references = page,
+
+		var result = PaginateAndStore(allResults, ref skip, take);
+
+		return scope.Outcome($"{result.Items.Length}/{result.Total} reference(s)", new {
+			total_references = result.Total,
+			skip, take,
+			references = result.Items,
+			page_token = result.PageToken,
+			has_more   = result.HasMore,
 			_caution   = AdhocCaution(projectPath)
 		});
 	}

--- a/src/RoslynMcp/Tools/Analysis/GetLineCountTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetLineCountTool.cs
@@ -8,7 +8,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class GetLineCountTool : RoslynMcpTool
 {
-    public GetLineCountTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+    public GetLineCountTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 
     [McpServerTool(Name = "roslyn_get_line_count", ReadOnly = true)]
     [Description(

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
@@ -7,7 +7,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class GetSymbolDefinitionTool : RoslynMcpTool
 {
-	public GetSymbolDefinitionTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public GetSymbolDefinitionTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_get_symbol_definition", ReadOnly = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class GetSymbolDocumentationTool : RoslynMcpTool
 {
-	public GetSymbolDocumentationTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public GetSymbolDocumentationTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_get_symbol_documentation", ReadOnly = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolsInScopeTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolsInScopeTool.cs
@@ -8,7 +8,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class GetSymbolsInScopeTool : RoslynMcpTool
 {
-	public GetSymbolsInScopeTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public GetSymbolsInScopeTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_get_symbols_in_scope", ReadOnly = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Analysis/GetTriviaTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetTriviaTool.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class GetTriviaTool : RoslynMcpTool
 {
-    public GetTriviaTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+    public GetTriviaTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 
     [McpServerTool(Name = "roslyn_get_trivia", ReadOnly = true)]
     [Description(

--- a/src/RoslynMcp/Tools/Analysis/GetUsingsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetUsingsTool.cs
@@ -8,7 +8,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class GetUsingsTool : RoslynMcpTool
 {
-	public GetUsingsTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public GetUsingsTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_get_usings", ReadOnly = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Analysis/ListTypesTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ListTypesTool.cs
@@ -7,7 +7,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class ListTypesTool : RoslynMcpTool
 {
-	public ListTypesTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public ListTypesTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_list_types", ReadOnly = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Analysis/ProjectInfoTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ProjectInfoTool.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class ProjectInfoTool : RoslynMcpTool
 {
-	public ProjectInfoTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public ProjectInfoTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	// Matches a TFM segment in a path like ...\net8.0\... or .../net11.0/...
 	private static readonly Regex TfmPattern = new(@"[/\\](net\d+\.\d+(?:-\w+)?)[/\\]", RegexOptions.Compiled);

--- a/src/RoslynMcp/Tools/Analysis/ReadFileTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ReadFileTool.cs
@@ -8,7 +8,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class ReadFileTool : RoslynMcpTool
 {
-    public ReadFileTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+    public ReadFileTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 
     [McpServerTool(Name = "roslyn_read_file", ReadOnly = true)]
     [Description(

--- a/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class SymbolInfoTool : RoslynMcpTool
 {
-	public SymbolInfoTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public SymbolInfoTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_get_symbol_info", ReadOnly = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Analysis/TypeHierarchyTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/TypeHierarchyTool.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class TypeHierarchyTool : RoslynMcpTool
 {
-	public TypeHierarchyTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public TypeHierarchyTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_get_type_hierarchy", ReadOnly = true)]
 	[Description(
@@ -20,13 +20,19 @@ internal sealed class TypeHierarchyTool : RoslynMcpTool
 		[Description("The type name, e.g. 'WindowTracker' or 'RoslynMcp.WorkspaceManager'.")] string typeName,
 		[Description(ProjectPathDescription)] string projectPath,
 		[Description("Number of derived types/interfaces to skip (for paging). Default: 0.")] int skip = 0,
-		[Description("Maximum number of derived types/interfaces to return. Default: 50, max: 200.")] int take = 50)
+		[Description("Maximum number of derived types/interfaces to return. Default: 50, max: 200.")] int take = 50,
+		[Description("Token from a previous response to get the next page without re-executing the query.")] string? page_token = null)
 	{
 		using var scope = BeginTool("roslyn_get_type_hierarchy", typeName);
+
+		take = Math.Clamp(take, 1, 200);
+
+		var cachedPage = TryServeCachedPage<string>(scope, page_token, ref skip, take);
+		if(cachedPage is not null)
+			return cachedPage;
+
 		if(!TryGetCompilation(projectPath, out var compilation, out var error))
 			return error;
-		
-		take = Math.Clamp(take, 1, 200);
 		
 		var type        = FindType(compilation, typeName);
 		
@@ -56,9 +62,9 @@ internal sealed class TypeHierarchyTool : RoslynMcpTool
 		// Page both interfaces
 		var combined = allInterfaces.Concat(allDerived).ToArray()
 		;
-		var page     = Paginate(combined, ref skip, take);
-		
-		return scope.Outcome($"{page.Length} interface(s)/derived", new {
+		var result   = PaginateAndStore(combined, ref skip, take);
+
+		return scope.Outcome($"{result.Items.Length} interface(s)/derived", new {
 			type_name           = type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
 			type_kind           = type.TypeKind.ToString().ToLowerInvariant(),
 			base_types          = baseTypes,
@@ -66,7 +72,9 @@ internal sealed class TypeHierarchyTool : RoslynMcpTool
 			total_derived_types = allDerived.Length,
 			skip,
 			take,
-			interfaces_and_derived = page,
+			interfaces_and_derived = result.Items,
+			page_token          = result.PageToken,
+			has_more            = result.HasMore,
 			_caution            = AdhocCaution(projectPath)
 		});
 	}

--- a/src/RoslynMcp/Tools/Analysis/TypeMembersTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/TypeMembersTool.cs
@@ -7,7 +7,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class TypeMembersTool : RoslynMcpTool
 {
-	public TypeMembersTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public TypeMembersTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_get_type_members", ReadOnly = true)]
 	[Description(
@@ -25,13 +25,19 @@ internal sealed class TypeMembersTool : RoslynMcpTool
 		string? memberKind = null,
 
 		[Description("Number of members to skip (for paging). Default: 0.")] int skip = 0,
-		[Description("Maximum number of members to return. Default: 50, max: 200.")] int take = 50)
+		[Description("Maximum number of members to return. Default: 50, max: 200.")] int take = 50,
+		[Description("Token from a previous response to get the next page without re-executing the query.")] string? page_token = null)
 	{
 		using var scope = BeginTool("roslyn_get_type_members", typeName);
+
+		take = Math.Clamp(take, 1, 200);
+
+		var cachedPage = TryServeCachedPage<object?>(scope, page_token, ref skip, take);
+		if(cachedPage is not null)
+			return cachedPage;
+
 		if(!TryGetCompilation(projectPath, out var compilation, out var error))
 			return error;
-		
-		take = Math.Clamp(take, 1, 200);
 		
 		var type = FindType(compilation, typeName);
 		
@@ -46,16 +52,17 @@ internal sealed class TypeMembersTool : RoslynMcpTool
 				.Where(m => m is not null)
 		];
 		
-		var page = Paginate(allMembers, ref skip, take);
-		
-		return scope.Outcome($"{page.Length}/{allMembers.Length} member(s)", new {
-			type_name = type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-			type_kind = type.TypeKind.ToString().ToLowerInvariant(),
-			total_members = allMembers.Length,
-			skip,
-			take,
-			members   = page,
-			_caution  = AdhocCaution(projectPath)
+		var result = PaginateAndStore(allMembers, ref skip, take);
+
+		return scope.Outcome($"{result.Items.Length}/{result.Total} member(s)", new {
+			type_name     = type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+			type_kind     = type.TypeKind.ToString().ToLowerInvariant(),
+			total_members = result.Total,
+			skip, take,
+			members    = result.Items,
+			page_token = result.PageToken,
+			has_more   = result.HasMore,
+			_caution   = AdhocCaution(projectPath)
 		});
 	}
 	

--- a/src/RoslynMcp/Tools/Build/BuildTool.cs
+++ b/src/RoslynMcp/Tools/Build/BuildTool.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class BuildTool : RoslynMcpTool
 {
-	public BuildTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public BuildTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	// Diagnostic codes to ignore (non-actionable SDK/tooling warnings).
 	private static readonly HashSet<string> IgnoredDiagnostics = new(StringComparer.OrdinalIgnoreCase) {

--- a/src/RoslynMcp/Tools/Build/CleanSolutionTool.cs
+++ b/src/RoslynMcp/Tools/Build/CleanSolutionTool.cs
@@ -7,7 +7,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class CleanSolutionTool : RoslynMcpTool
 {
-	public CleanSolutionTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public CleanSolutionTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_clean_solution", Destructive = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Build/RestorePackagesTool.cs
+++ b/src/RoslynMcp/Tools/Build/RestorePackagesTool.cs
@@ -7,7 +7,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class RestorePackagesTool : RoslynMcpTool
 {
-	public RestorePackagesTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public RestorePackagesTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_restore_packages", Idempotent = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
@@ -15,7 +15,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class ReplaceInCodeTool : RoslynMcpTool
 {
-	public ReplaceInCodeTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public ReplaceInCodeTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_replace_in_code", Destructive = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
@@ -12,7 +12,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class ReplaceInFileTool : RoslynMcpTool
 {
-	public ReplaceInFileTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public ReplaceInFileTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_replace_in_file", Destructive = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Rename/ApplyRenameTool.cs
+++ b/src/RoslynMcp/Tools/Rename/ApplyRenameTool.cs
@@ -8,7 +8,7 @@ internal sealed class ApplyRenameTool : RoslynMcpTool
 {
 	readonly ApprovalStore approvals;
 	
-	public ApplyRenameTool(WorkspaceResolver workspace, ApprovalStore approvals, FileLogger logger) : base(workspace, logger)
+	public ApplyRenameTool(WorkspaceResolver workspace, ApprovalStore approvals, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache)
 	{
 		this.approvals = approvals;
 	}

--- a/src/RoslynMcp/Tools/Rename/PreviewRenameTool.cs
+++ b/src/RoslynMcp/Tools/Rename/PreviewRenameTool.cs
@@ -11,7 +11,7 @@ internal sealed class PreviewRenameTool : RoslynMcpTool
 {
 	readonly ApprovalStore approvals;
 	
-	public PreviewRenameTool(WorkspaceResolver workspace, ApprovalStore approvals, FileLogger logger) : base(workspace, logger)
+	public PreviewRenameTool(WorkspaceResolver workspace, ApprovalStore approvals, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache)
 	{
 		this.approvals = approvals;
 	}

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -11,16 +11,18 @@ internal abstract partial class RoslynMcpTool
 {
 	protected readonly WorkspaceResolver workspace;
 	protected readonly FileLogger         logger;
-	
+	protected readonly PaginationCache    paginationCache;
+
 	// Tracks the in-flight scope so TryGetCompilation/TryGetProject can set workspace mode without
 	// requiring callers to thread the scope through as a parameter.
 	[ThreadStatic]
 	private static ToolScope? activeScope;
-	
-	protected RoslynMcpTool(WorkspaceResolver workspace, FileLogger logger)
+
+	protected RoslynMcpTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache)
 	{
-		this.workspace = workspace;
-		this.logger    = logger;
+		this.workspace       = workspace;
+		this.logger          = logger;
+		this.paginationCache = paginationCache;
 	}
 	
 	/// <summary>
@@ -329,6 +331,50 @@ internal abstract partial class RoslynMcpTool
 		return items.AsSpan(skip, Math.Min(take, items.Length - skip)).ToArray();
 	}
 
+	/// <summary>ReadOnlyMemory overload — zero-copy slice from cache.</summary>
+	protected static T[] Paginate<T>(ReadOnlyMemory<T> items, ref int skip, int take)
+	{
+		skip = Math.Clamp(skip, 0, items.Length);
+
+		return items.Slice(skip, Math.Min(take, items.Length - skip)).ToArray();
+	}
+
+	/// <summary>
+	///     Cache-hit path: if the token is valid, returns a standardized paged response directly.
+	///     Returns null on miss — caller should compute results and call <see cref="PaginateAndStore{T}"/>.
+	///     Subsequent-page responses use a common shape (items/total/page_token/has_more);
+	///     tool-specific metadata is only included in the first-page response.
+	/// </summary>
+	protected object? TryServeCachedPage<T>(ToolScope scope, string? pageToken, ref int skip, int take)
+	{
+		if(pageToken is null || !paginationCache.TryGet<T>(pageToken, out var cached))
+			return null;
+
+		var page = Paginate(cached, ref skip, take);
+
+		return scope.Outcome($"{page.Length}/{cached.Length}", new {
+			items      = page,
+			total      = cached.Length,
+			skip,
+			take,
+			page_token = pageToken,
+			has_more   = skip + page.Length < cached.Length
+		});
+	}
+
+	/// <summary>
+	///     Cache-miss path: stores <paramref name="allResults"/> in the pagination cache and
+	///     returns a paginated slice with token for subsequent pages.
+	/// </summary>
+	protected PaginatedResult<T> PaginateAndStore<T>(T[] allResults, ref int skip, int take)
+	{
+		var token   = paginationCache.Store(allResults);
+		var page    = Paginate(allResults, ref skip, take);
+		var hasMore = skip + page.Length < allResults.Length;
+
+		return new PaginatedResult<T>(page, allResults.Length, skip, take, token, hasMore);
+	}
+
 	/// <summary>
 	///     Resolves a relative file path to a full path. Tries <paramref name="rootPath"/> first;
 	///     if the file isn't found there, walks subdirectories looking for a suffix match.
@@ -407,3 +453,12 @@ internal abstract partial class RoslynMcpTool
 	protected static string NormalizePath(string filePath)
 		=> filePath.Replace('/', Path.DirectorySeparatorChar);
 }
+
+internal sealed record PaginatedResult<T>(
+	T[]    Items,
+	int    Total,
+	int    Skip,
+	int    Take,
+	string PageToken,
+	bool   HasMore
+);

--- a/src/RoslynMcp/Tools/Search/ListFilesTool.cs
+++ b/src/RoslynMcp/Tools/Search/ListFilesTool.cs
@@ -7,7 +7,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class ListFilesTool : RoslynMcpTool
 {
-	public ListFilesTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public ListFilesTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_list_files", ReadOnly = true)]
 	[Description(

--- a/src/RoslynMcp/Tools/Search/SearchFilesTool.cs
+++ b/src/RoslynMcp/Tools/Search/SearchFilesTool.cs
@@ -8,7 +8,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class SearchFilesTool : RoslynMcpTool
 {
-	public SearchFilesTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public SearchFilesTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[McpServerTool(Name = "roslyn_search_files", ReadOnly = true)]
 	[Description(
@@ -21,13 +21,18 @@ internal sealed class SearchFilesTool : RoslynMcpTool
 		[Description("File glob pattern (e.g., '*.cs', '*.csproj'). Default: '*.cs'.")] string? filePattern = null,
 		[Description("Case-sensitive matching. Default: false.")] bool caseSensitive = false,
 		[Description("Number of results to skip (for paging). Default: 0.")] int skip = 0,
-		[Description("Maximum number of results to return. Default: 50, max: 200.")] int take = 50
+		[Description("Maximum number of results to return. Default: 50, max: 200.")] int take = 50,
+		[Description("Token from a previous response to get the next page without re-executing the query.")] string? page_token = null
 	)
 	{
 		using var scope = BeginTool("roslyn_search_files", pattern);
 		filePattern ??= "*.cs";
-		take		  = Math.Clamp(take, 1, 200);
-		skip		  = Math.Max(0, skip);
+		take          = Math.Clamp(take, 1, 200);
+		skip          = Math.Max(0, skip);
+
+		var cachedPage = TryServeCachedPage<object>(scope, page_token, ref skip, take);
+		if(cachedPage is not null)
+			return cachedPage;
 		
 		Regex regex;
 		
@@ -82,18 +87,18 @@ internal sealed class SearchFilesTool : RoslynMcpTool
 				}
 			}
 		
-		var totalMatches = allMatches.Count;
-		MatchResult[] pagedMatches = [.. allMatches.Skip(skip).Take(take)]
-		;
-		
-		scope.Outcome($"{totalMatches} match(es)");
-		
+		var allResults = allMatches.ToArray();
+		var result     = PaginateAndStore(allResults, ref skip, take);
+
+		scope.Outcome($"{result.Total} match(es)");
+
 		return new {
-			matches		  = pagedMatches,
-			total_matches = totalMatches,
-			returned	  = pagedMatches.Length,
-			has_more	  = skip + pagedMatches.Length < totalMatches,
-			_caution	  = AdhocCaution(projectPath)
+			matches       = result.Items,
+			total_matches = result.Total,
+			returned      = result.Items.Length,
+			page_token    = result.PageToken,
+			has_more      = result.HasMore,
+			_caution      = AdhocCaution(projectPath)
 		};
 	}
 	

--- a/src/RoslynMcp/Tools/Search/SemanticSearchTool.cs
+++ b/src/RoslynMcp/Tools/Search/SemanticSearchTool.cs
@@ -11,7 +11,7 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class SemanticSearchTool : RoslynMcpTool
 {
-	public SemanticSearchTool(WorkspaceResolver workspace, FileLogger logger) : base(workspace, logger) { }
+	public SemanticSearchTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
 	
 	[
 		McpServerTool(Name = "roslyn_semantic_search", ReadOnly = true), Description(
@@ -44,15 +44,22 @@ internal sealed class SemanticSearchTool : RoslynMcpTool
 		int skip = 0,
 		
 		[Description("Maximum number of results to return. Default: 50, max: 200.")]
-		int take = 50
+		int take = 50,
+
+		[Description("Token from a previous response to get the next page without re-executing the query.")]
+		string? page_token = null
 	)
 	{
 		using var scope = BeginTool("roslyn_semantic_search", pattern);
-		context		??= "all";
-		filePattern	??= "*.cs";
-		take		  = Math.Clamp(take, 1, 200);
-		skip		  = Math.Max(0, skip);
-		
+		context     ??= "all";
+		filePattern ??= "*.cs";
+		take          = Math.Clamp(take, 1, 200);
+		skip          = Math.Max(0, skip);
+
+		var cachedPage = TryServeCachedPage<SemanticMatchResult>(scope, page_token, ref skip, take);
+		if(cachedPage is not null)
+			return cachedPage;
+
 		// Validate context parameter
 		var validContexts = new[] { "comments", "strings", "identifiers", "code", "xmldocs", "all" };
 		
@@ -142,17 +149,17 @@ internal sealed class SemanticSearchTool : RoslynMcpTool
 				}
 			}
 		
-		var totalMatches = allMatches.Count;
-		SemanticMatchResult[] pagedMatches = [.. allMatches.Skip(skip).Take(take)]
-		;
-		
-		scope.Outcome($"{totalMatches} match(es)");
-		
+		var allResults = allMatches.ToArray();
+		var result     = PaginateAndStore(allResults, ref skip, take);
+
+		scope.Outcome($"{result.Total} match(es)");
+
 		return new {
-			matches		  = pagedMatches,
-			total_matches = totalMatches,
-			returned	  = pagedMatches.Length,
-			has_more	  = skip + pagedMatches.Length < totalMatches,
+			matches       = result.Items,
+			total_matches = result.Total,
+			returned      = result.Items.Length,
+			page_token    = result.PageToken,
+			has_more      = result.HasMore,
 			context		  = context,
 			_caution	  = AdhocCaution(projectPath)
 		};

--- a/src/RoslynMcp/WorkspaceResolver.cs
+++ b/src/RoslynMcp/WorkspaceResolver.cs
@@ -8,11 +8,13 @@ namespace RoslynMcp;
 /// </summary>
 internal sealed class WorkspaceResolver
 {
-	readonly WorkspaceManager manager;
+	readonly WorkspaceManager  manager;
+	readonly PaginationCache   paginationCache;
 
-	public WorkspaceResolver(WorkspaceManager manager)
+	public WorkspaceResolver(WorkspaceManager manager, PaginationCache paginationCache)
 	{
-		this.manager = manager;
+		this.manager         = manager;
+		this.paginationCache = paginationCache;
 	}
 
 	/// <summary>
@@ -103,5 +105,6 @@ internal sealed class WorkspaceResolver
 		var (resolved, _) = ResolveWithKind(projectPath);
 
 		manager.InvalidateFile(resolved, fullPath);
+		paginationCache.InvalidateAll();
 	}
 }

--- a/src/TestHarness/Program.cs
+++ b/src/TestHarness/Program.cs
@@ -254,6 +254,62 @@ tests.Add(await RunTestAsync(
 	data => data?["total_references"]?.GetValue<int>() > 0 && data?["references"]?.AsArray().Count > 0
 ));
 
+// ── Pagination token test: page 1 with small take, then page 2 via token ──
+{
+	Console.Write($"  {"roslyn_find_references: pagination token (page 1)",-50} ");
+	var sw1 = System.Diagnostics.Stopwatch.StartNew();
+
+	await SendAsync(new {
+		jsonrpc = "2.0",
+		id      = reqId++,
+		method  = "tools/call",
+		@params = new { name = "roslyn_find_references", arguments = new { symbolName = "WorkspaceManager", projectPath = targetPath, take = 2 } }
+	});
+
+	var resp1 = await ReceiveAsync();
+	sw1.Stop();
+	var content1 = resp1?["result"]?["content"]?[0]?["text"]?.GetValue<string>();
+	var page1 = content1 is not null ? System.Text.Json.Nodes.JsonNode.Parse(content1) : null;
+	var token = page1?["page_token"]?.GetValue<string>();
+	var hasMore = page1?["has_more"]?.GetValue<bool>() == true;
+	var page1Refs = page1?["references"]?.AsArray();
+
+	if(token is not null && hasMore && page1Refs?.Count == 2) {
+		tests.Add((true, $"PASS  [{sw1.ElapsedMilliseconds}ms]"));
+		Console.WriteLine($"PASS  [{sw1.ElapsedMilliseconds}ms]");
+	}
+	else {
+		tests.Add((false, $"FAIL  (no page_token or has_more) [{sw1.ElapsedMilliseconds}ms]"));
+		Console.WriteLine($"FAIL  (no page_token or has_more) [{sw1.ElapsedMilliseconds}ms]");
+	}
+
+	Console.Write($"  {"roslyn_find_references: pagination token (page 2)",-50} ");
+	var sw2 = System.Diagnostics.Stopwatch.StartNew();
+
+	await SendAsync(new {
+		jsonrpc = "2.0",
+		id      = reqId++,
+		method  = "tools/call",
+		@params = new { name = "roslyn_find_references", arguments = new { symbolName = "WorkspaceManager", projectPath = targetPath, skip = 2, take = 2, page_token = token ?? "" } }
+	});
+
+	var resp2 = await ReceiveAsync();
+	sw2.Stop();
+	var content2 = resp2?["result"]?["content"]?[0]?["text"]?.GetValue<string>();
+	var page2 = content2 is not null ? System.Text.Json.Nodes.JsonNode.Parse(content2) : null;
+	var page2Items = page2?["items"]?.AsArray();
+	var page2Token = page2?["page_token"]?.GetValue<string>();
+
+	if(page2Items?.Count > 0 && page2Token == token) {
+		tests.Add((true, $"PASS  [{sw2.ElapsedMilliseconds}ms]"));
+		Console.WriteLine($"PASS  [{sw2.ElapsedMilliseconds}ms]");
+	}
+	else {
+		tests.Add((false, $"FAIL  (page 2 missing items or wrong token) [{sw2.ElapsedMilliseconds}ms]"));
+		Console.WriteLine($"FAIL  (page 2 missing items or wrong token) [{sw2.ElapsedMilliseconds}ms]");
+	}
+}
+
 tests.Add(await RunTestAsync(
 	"roslyn_get_symbol_definition: find WorkspaceManager declaration",
 	"roslyn_get_symbol_definition",


### PR DESCRIPTION
## Summary

Add `PaginationCache` with token-based paging so agents can get subsequent pages without re-executing the full query. Same pattern as `roslyn_preview_rename` tokens — agents already understand this.

**First call:** returns results + `page_token` + `has_more`
**Subsequent calls:** pass `page_token` to serve from cache (fast path)
**Cache miss:** token expired or invalid → re-run the query

### Infrastructure
- `PaginationCache` — DI singleton, sliding-window 60s TTL, max 50 entries, LRU eviction
- `TryServeCachedPage<T>` — one-line cache-hit in base class, standardized response shape
- `PaginateAndStore<T>` — cache-miss path, stores + returns first page with token
- `InvalidateAll()` called from `WorkspaceResolver.InvalidateFile`
- All 26 tool constructors updated to accept `PaginationCache` via DI

### Wired into 7 paginated tools
FindReferencesTool, FindImplementationsTool, TypeHierarchyTool, TypeMembersTool, FileOutlineTool, SearchFilesTool, SemanticSearchTool

### Test harness
- 2 new tests: page 1 (small take, verify token + has_more) and page 2 (pass token, verify cache hit)
- **29/29 passing**

### Remaining (tracked in scratchpad)
ListFilesTool, GetTriviaTool, ListTypesTool need `skip` parameter added before they can use the cache.

### Design doc
`docs/plans/pagination-cache.md`

Fixes #40

## Test plan

- [x] 29/29 test harness passing
- [x] Page 1 returns `page_token` and `has_more: true`
- [x] Page 2 with token serves from cache (same token returned, different items)
- [ ] Verify token expires after 60s of inactivity
- [ ] Verify `InvalidateAll` clears cache when files are edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)