### PR TITLE
feat: add roslyn_get_member_body + DRY FindSymbol/FormatSymbolName

### DIFF
--- a/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
@@ -124,19 +124,6 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 		return new { error = $"'{symbolName}' is not a type or method — cannot find implementations." };
 	}
 	
-	private static ISymbol? FindSymbol(Compilation compilation, string name, string? inType)
-	{
-		if(inType is not null) {
-		
-			var type = compilation.GetTypeByMetadataName(inType)
-				?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(inType));
-			
-			return type?.GetMembers(name).FirstOrDefault();
-		}
-		
-		// Global search for type or member.
-		return compilation.GlobalNamespace.Accept(new AnySymbolFinder(name));
-	}
 	
 	private static string FormatMethod(IMethodSymbol method)
 	{

--- a/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
@@ -75,15 +75,4 @@ internal sealed class FindReferencesTool : RoslynMcpTool
 		});
 	}
 	
-	private static ISymbol? FindSymbol(Compilation compilation, string name, string? inType)
-	{
-		if(inType is not null) {
-			var type = compilation.GetTypeByMetadataName(inType)
-				?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(inType));
-			
-			return type?.GetMembers(name).FirstOrDefault();
-		}
-		
-		return compilation.GlobalNamespace.Accept(new AnySymbolFinder(name));
-	}
 }

--- a/src/RoslynMcp/Tools/Analysis/GetMemberBodyTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetMemberBodyTool.cs
@@ -1,0 +1,99 @@
+using System.ComponentModel;
+using Microsoft.CodeAnalysis;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Tools;
+
+[McpServerToolType]
+internal sealed class GetMemberBodyTool : RoslynMcpTool
+{
+	public GetMemberBodyTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
+
+	[McpServerTool(Name = "roslyn_get_member_body", ReadOnly = true)]
+	[Description(
+		"Returns the full source of a single method, property, field, or type by name. " +
+		"Much more token-efficient than reading an entire file — returns only the declaration you need. " +
+		"For partial types/methods with multiple declarations, returns all parts.")]
+	public async Task<object> GetMemberBody(
+		[Description("The symbol name, e.g. 'GetCompilation', 'RootPath', 'WorkspaceManager'.")] string symbolName,
+		[Description(ProjectPathDescription)] string projectPath,
+		[Description("Optional containing type to disambiguate, e.g. 'WorkspaceManager'.")] string? containingType = null)
+	{
+		using var scope = BeginTool("roslyn_get_member_body", symbolName);
+		if(!TryGetCompilation(projectPath, out var compilation, out var error))
+			return error;
+
+		var rootPath = workspace.GetRootPath(projectPath);
+		var symbol   = FindSymbol(compilation, symbolName, containingType);
+
+		if(symbol is null)
+			return scope.Failed("symbol not found", new {
+				error = $"Symbol '{symbolName}' not found. Use get_type_members or find_references to verify the name."
+			});
+
+		var syntaxRefs = symbol.DeclaringSyntaxReferences;
+
+		if(syntaxRefs.Length == 0)
+			return new {
+				symbol_name = FormatSymbolName(symbol),
+				symbol_kind = symbol.Kind.ToString().ToLowerInvariant(),
+				location    = "metadata",
+				message     = "This symbol is defined in metadata (compiled assembly), not source code."
+			};
+
+		var parts = new List<object>();
+
+		for(var i = 0; i < syntaxRefs.Length; i++) {
+
+			var syntaxRef = syntaxRefs[i];
+			var node      = await syntaxRef.GetSyntaxAsync();
+			var tree      = node.SyntaxTree;
+			var text      = await tree.GetTextAsync();
+			var span      = tree.GetLineSpan(node.Span);
+			var startLine = span.StartLinePosition.Line;
+			var endLine   = span.EndLinePosition.Line;
+
+			// Extract source lines with 1-based line numbers.
+			var lines = new string[endLine - startLine + 1];
+
+			for(var ln = startLine; ln <= endLine; ln++)
+				lines[ln - startLine] = text.Lines[ln].ToString();
+
+			var filePath = string.IsNullOrEmpty(tree.FilePath)
+				? "?"
+				: Path.GetRelativePath(rootPath, tree.FilePath)
+			;
+
+			parts.Add(new {
+				file       = filePath,
+				start_line = startLine + 1,
+				end_line   = endLine + 1,
+				body       = string.Join("\n", lines),
+				part_index = syntaxRefs.Length > 1 ? i + 1 : (int?) null
+			});
+		}
+
+		var totalLines = parts.Cast<dynamic>().Sum(p => (int) p.end_line - (int) p.start_line + 1);
+
+		return scope.Outcome($"{totalLines} line(s)", syntaxRefs.Length == 1
+			? new {
+				symbol_name = FormatSymbolName(symbol),
+				symbol_kind = symbol.Kind.ToString().ToLowerInvariant(),
+				file        = ((dynamic) parts[0]).file,
+				start_line  = ((dynamic) parts[0]).start_line,
+				end_line    = ((dynamic) parts[0]).end_line,
+				body        = ((dynamic) parts[0]).body,
+				_caution    = AdhocCaution(projectPath)
+			}
+			: (object) new {
+				symbol_name = FormatSymbolName(symbol),
+				symbol_kind = symbol.Kind.ToString().ToLowerInvariant(),
+				parts,
+				note        = $"Partial declaration — {syntaxRefs.Length} parts across {parts.Select(p => ((dynamic) p).file).Distinct().Count()} file(s).",
+				_caution    = AdhocCaution(projectPath)
+			}
+		);
+	}
+
+
+}

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
@@ -58,37 +58,7 @@ internal sealed class GetSymbolDefinitionTool : RoslynMcpTool
 		};
 	}
 	
-	private static ISymbol? FindSymbol(Compilation compilation, string name, string? inType)
-	{
-		if(inType is not null) {
-		
-			var type = compilation.GetTypeByMetadataName(inType)
-				?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(inType));
-			
-			return type?.GetMembers(name).FirstOrDefault();
-		}
-		
-		// Global search: try as type first, then as member.
-		var typeSymbol = compilation.GetTypeByMetadataName(name)
-			?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(name));
-		
-		if(typeSymbol is not null)
-			return typeSymbol;
-		
-		return compilation.GlobalNamespace.Accept(new AnySymbolFinder(name));
-	}
 	
-	private static string FormatSymbolName(ISymbol symbol)
-	{
-		if(symbol is INamedTypeSymbol)
-			return symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
-		
-		var containingType = symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
-		
-		return containingType is not null
-			? $"{containingType}.{symbol.Name}"
-			: symbol.Name;
-	}
 	
 	private static string FormatSignature(ISymbol symbol)
 	{

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
@@ -54,37 +54,7 @@ internal sealed class GetSymbolDocumentationTool : RoslynMcpTool
 		};
 	}
 	
-	private static ISymbol? FindSymbol(Compilation compilation, string name, string? inType)
-	{
-		if(inType is not null) {
-		
-			var type = compilation.GetTypeByMetadataName(inType)
-				?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(inType));
-			
-			return type?.GetMembers(name).FirstOrDefault();
-		}
-		
-		// Global search: try as type first, then as member.
-		var typeSymbol = compilation.GetTypeByMetadataName(name)
-			?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(name));
-		
-		if(typeSymbol is not null)
-			return typeSymbol;
-		
-		return compilation.GlobalNamespace.Accept(new AnySymbolFinder(name));
-	}
 	
-	private static string FormatSymbolName(ISymbol symbol)
-	{
-		if(symbol is INamedTypeSymbol)
-			return symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
-		
-		var containingType = symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
-		
-		return containingType is not null
-			? $"{containingType}.{symbol.Name}"
-			: symbol.Name;
-	}
 	
 	private static DocumentationComment ParseDocumentation(string xml)
 	{

--- a/src/RoslynMcp/Tools/Rename/PreviewRenameTool.cs
+++ b/src/RoslynMcp/Tools/Rename/PreviewRenameTool.cs
@@ -59,17 +59,6 @@ internal sealed class PreviewRenameTool : RoslynMcpTool
 		);
 	}
 	
-	private static ISymbol? FindSymbol(Compilation compilation, string name, string? inType)
-	{
-		if(inType is not null) {
-			var type = compilation.GetTypeByMetadataName(inType)
-				?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(inType));
-			
-			return type?.GetMembers(name).FirstOrDefault();
-		}
-		
-		return compilation.GlobalNamespace.Accept(new AnySymbolFinder(name));
-	}
 	
 	private static string SymbolKey(ISymbol symbol)
 	{

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -452,6 +452,43 @@ internal abstract partial class RoslynMcpTool
 	/// </summary>
 	protected static string NormalizePath(string filePath)
 		=> filePath.Replace('/', Path.DirectorySeparatorChar);
+
+	/// <summary>
+	///     Resolves a symbol by name from a compilation. When <paramref name="containingType"/> is
+	///     provided, searches that type's members. Otherwise tries type-first lookup (metadata name →
+	///     SimpleNameFinder) before falling back to AnySymbolFinder for members.
+	/// </summary>
+	protected static ISymbol? FindSymbol(Compilation compilation, string name, string? containingType)
+	{
+		if(containingType is not null) {
+
+			var type = compilation.GetTypeByMetadataName(containingType)
+				?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(containingType));
+
+			return type?.GetMembers(name).FirstOrDefault();
+		}
+
+		var typeSymbol = compilation.GetTypeByMetadataName(name)
+			?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(name));
+
+		if(typeSymbol is not null)
+			return typeSymbol;
+
+		return compilation.GlobalNamespace.Accept(new AnySymbolFinder(name));
+	}
+
+	/// <summary>
+	///     Formats a symbol's display name: fully qualified for types, ContainingType.Name for members.
+	/// </summary>
+	protected static string FormatSymbolName(ISymbol symbol)
+	{
+		if(symbol is INamedTypeSymbol)
+			return symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+
+		var ct = symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+
+		return ct is not null ? $"{ct}.{symbol.Name}" : symbol.Name;
+	}
 }
 
 internal sealed record PaginatedResult<T>(

--- a/src/TestHarness/Program.cs
+++ b/src/TestHarness/Program.cs
@@ -205,6 +205,26 @@ tests.Add(await RunTestAsync(
 	data => data?["usings"]?.AsArray().Count > 0
 ));
 
+Console.WriteLine("\nMember Body Tools (2 tests)");
+Console.WriteLine("─────────────────────────────────────────────────────────────");
+
+tests.Add(await RunTestAsync(
+	"roslyn_get_member_body: single method",
+	"roslyn_get_member_body",
+	new { symbolName = "GetCompilation", containingType = "WorkspaceManager", projectPath = targetPath },
+	data => data?["body"]?.GetValue<string>().Contains("GetCompilation") == true
+		 && data?["start_line"]?.GetValue<int>() > 0
+		 && data?["symbol_kind"]?.GetValue<string>() == "method"
+));
+
+tests.Add(await RunTestAsync(
+	"roslyn_get_member_body: partial class (multiple parts)",
+	"roslyn_get_member_body",
+	new { symbolName = "WorkspaceManager", projectPath = targetPath },
+	data => data?["parts"]?.AsArray().Count > 1
+		 && data?["note"]?.GetValue<string>().Contains("Partial") == true
+));
+
 Console.WriteLine("\nType Understanding Tools (4 tests)");
 Console.WriteLine("─────────────────────────────────────────────────────────────");
 


### PR DESCRIPTION
## Summary

**New tool: `roslyn_get_member_body`** — returns the full source of a single method, property, field, or type by name. The highest-value token reduction tool: 20 lines instead of reading a 600-line file.

- Handles partial types/methods — returns all parts with `part_index` and a note
- Metadata-only symbols → clear message (same pattern as `get_symbol_definition`)
- Uses `DeclaringSyntaxReferences` → syntax node → source text slice

**DRY extraction to `RoslynMcpTool` base class:**
- `FindSymbol` — was duplicated 6x across tools (PreviewRenameTool, FindReferencesTool, FindImplementationsTool, GetSymbolDefinitionTool, GetSymbolDocumentationTool, GetMemberBodyTool). Consolidated into the type-first variant (prefers exact type matches over accidental member name hits).
- `FormatSymbolName` — was duplicated 3x (GetSymbolDefinitionTool, GetSymbolDocumentationTool, GetMemberBodyTool). Extracted to base class.

**Net: +156 lines (new tool + base class methods), -95 lines (9 eliminated copies).**

Fixes #28

## Test plan

- [x] 31/31 test harness passing
- [x] `get_member_body` for single method: returns body, start_line, symbol_kind
- [x] `get_member_body` for partial class: returns multiple parts with "Partial" note
- [ ] Test with metadata-only symbol (e.g., `String`) — verify "metadata" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)