### PR TITLE
fix: harden list_types and find_references defaults

### DIFF
--- a/src/RoslynMcp/SymbolVisitors.cs
+++ b/src/RoslynMcp/SymbolVisitors.cs
@@ -42,6 +42,37 @@ internal sealed class SimpleNameFinder<T>(string name) : SymbolVisitor<T?>
 	}
 }
 
+/// <summary>Walks all types to collect ALL symbols (types and members) matching a simple name.</summary>
+internal sealed class AllSymbolsFinder(string name)
+{
+	readonly List<ISymbol> results = [];
+
+	public IReadOnlyList<ISymbol> Results => results;
+
+	public void Visit(INamespaceSymbol ns)
+	{
+		foreach(var m in ns.GetMembers()) {
+
+			if(m is INamespaceSymbol childNs)
+				Visit(childNs);
+			else if(m is INamedTypeSymbol type)
+				VisitType(type);
+		}
+	}
+
+	void VisitType(INamedTypeSymbol type)
+	{
+		if(type.Name == name)
+			results.Add(type);
+
+		foreach(var member in type.GetMembers(name))
+			results.Add(member);
+
+		foreach(var nested in type.GetTypeMembers())
+			VisitType(nested);
+	}
+}
+
 /// <summary>Walks all types to find the first symbol (type or member) matching a simple name.</summary>
 internal sealed class AnySymbolFinder(string name) : SymbolVisitor<ISymbol?>
 {

--- a/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
@@ -36,37 +36,63 @@ internal sealed class FindReferencesTool : RoslynMcpTool
 
 		var solution = workspace.GetSolution(projectPath);
 		var rootPath = workspace.GetRootPath(projectPath);
-		var symbol   = FindSymbol(compilation, symbolName, containingType);
 
-		if(symbol is null)
+		// When containingType is specified, search one symbol. Otherwise search ALL
+		// symbols matching the name — prevents silently incomplete results when
+		// multiple types have members with the same name.
+		ISymbol[] symbols;
+
+		if(containingType is not null) {
+
+			var symbol = FindSymbol(compilation, symbolName, containingType);
+			symbols = symbol is not null ? [symbol] : [];
+		}
+		else {
+
+			var finder = new AllSymbolsFinder(symbolName);
+			finder.Visit(compilation.GlobalNamespace);
+			symbols = [.. finder.Results];
+		}
+
+		if(symbols.Length == 0)
 			return scope.Failed("symbol not found", new { error = $"Symbol '{symbolName}' not found." });
 
-		var refs = await RoslynSymbolFinder.FindReferencesAsync(symbol, solution);
+		var allLocations = new List<string>();
 
-		var allResults = refs
-			.SelectMany(r => r.Locations)
-			.OrderBy(l => l.Location.SourceTree?.FilePath)
-			.ThenBy(l => l.Location.GetLineSpan().StartLinePosition.Line)
-			.Select(l => {
+		foreach(var sym in symbols) {
 
-				var span = l.Location.GetLineSpan();
-				var file = span.Path is { Length: > 0 } p
-					? Path.GetRelativePath(rootPath, p)
-					: "?";
+			var refs = await RoslynSymbolFinder.FindReferencesAsync(sym, solution);
 
-				return $"{file}:{span.StartLinePosition.Line + 1}";
-			})
+			allLocations.AddRange(
+				refs.SelectMany(r => r.Locations)
+					.Select(l => {
+
+						var span = l.Location.GetLineSpan();
+						var file = span.Path is { Length: > 0 } p
+							? Path.GetRelativePath(rootPath, p)
+							: "?";
+
+						return $"{file}:{span.StartLinePosition.Line + 1}";
+					})
+			);
+		}
+
+		var allResults = allLocations
 			.Distinct()
+			.Order()
 			.ToArray()
 		;
 
 		if(allResults.Length == 0)
 			return new { total_references = 0, skip, take, references = new[] { $"No references found for '{symbolName}'." } };
 
+		string[] symbolsSearched = [.. symbols.Select(s => FormatSymbolName(s)).Distinct()];
+
 		var result = PaginateAndStore(allResults, ref skip, take);
 
-		return scope.Outcome($"{result.Items.Length}/{result.Total} reference(s)", new {
+		return scope.Outcome($"{result.Items.Length}/{result.Total} reference(s) across {symbolsSearched.Length} symbol(s)", new {
 			total_references = result.Total,
+			symbols_searched = symbolsSearched,
 			skip, take,
 			references = result.Items,
 			page_token = result.PageToken,

--- a/src/RoslynMcp/Tools/Analysis/ListTypesTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ListTypesTool.cs
@@ -20,23 +20,25 @@ internal sealed class ListTypesTool : RoslynMcpTool
 	{
 		using var scope = BeginTool("roslyn_list_types", namespaceFilter);
 		if(!TryGetCompilation(projectPath, out var compilation, out var error))
-			return new[] { error.ToString()! };
-		
-		
-		var allTypes    = new List<INamedTypeSymbol>();
-		
+			return error;
+
+		var allTypes = new List<INamedTypeSymbol>();
+
 		CollectTypes(compilation.GlobalNamespace, allTypes);
-		
+
 		var filtered = allTypes
 			.Where(t => !t.IsImplicitlyDeclared)
+			// Without a namespace filter, only return types defined in source — not the
+			// thousands of types from referenced assemblies (the context-window bomb).
+			.Where(t => namespaceFilter is not null || t.Locations.Any(l => l.IsInSource))
 			.Where(t => MatchesNamespace(t, namespaceFilter))
 			.Where(t => MatchesKind(t, kindFilter))
 			.Select(t => SymbolFormatter.FormatType(t))
 			.Order()
 		;
-		
+
 		string[] results = [.. filtered];
-		
+
 		return results.Length > 0
 			? scope.Outcome($"{results.Length} type(s)", results)
 			: (object) new[] { "No types found matching the filters." };


### PR DESCRIPTION
## Summary

Two fixes that prevent agents from getting silently bad results:

**`roslyn_list_types` — no more context-window bomb (#29)**
When no `namespaceFilter` is given, only return types defined in source (`Locations.Any(l => l.IsInSource)`). Previously dumped every type from every referenced assembly — 829K+ characters of `<>f__AnonymousType` and framework types. Also fixed `error.ToString()` on anonymous object.

**`roslyn_find_references` — search all matching symbols (#29)**
When no `containingType` is given, now searches ALL symbols matching the name via new `AllSymbolsFinder` visitor — not just the first hit from `AnySymbolFinder`. Results are unioned and deduplicated. Response includes `symbols_searched` field so the agent knows exactly which symbols were covered.

Fixes #29

## Test plan

- [x] 31/31 test harness passing
- [ ] Call `roslyn_list_types` without `namespaceFilter` — verify only project types returned (not framework types)
- [ ] Call `roslyn_find_references` for a name that exists in multiple types — verify all references found

🤖 Generated with [Claude Code](https://claude.com/claude-code)