### PR TITLE
feat: add filtering/output parameters to 5 existing tools

### DIFF
--- a/src/RoslynMcp/Tools/Analysis/DiagnosticsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/DiagnosticsTool.cs
@@ -18,7 +18,8 @@ internal sealed class DiagnosticsTool : RoslynMcpTool
 		"SDK props, or source generators — use roslyn_build_project for those.")]
 	public object GetDiagnostics(
 		[Description(ProjectPathDescription)] string projectPath,
-		[Description("Optional relative file path to scope diagnostics, e.g. 'Core/WindowTracker.cs'. Omit for all files.")] string? filePath = null)
+		[Description("Optional relative file path to scope diagnostics, e.g. 'Core/WindowTracker.cs'. Omit for all files.")] string? filePath = null,
+		[Description("Severity filter: 'errors', 'warnings', or 'all'. Default: 'all' (errors and warnings).")] string? severity = null)
 	{
 		using var scope = BeginTool("roslyn_get_diagnostics", filePath);
 		if(!TryGetCompilation(projectPath, out var compilation, out var error))
@@ -43,9 +44,15 @@ internal sealed class DiagnosticsTool : RoslynMcpTool
 			diagnostics = compilation.GetDiagnostics();
 		}
 		
+		Func<Diagnostic, bool> severityFilter = severity?.ToLowerInvariant() switch {
+			"errors"   => d => d.Severity == DiagnosticSeverity.Error,
+			"warnings" => d => d.Severity == DiagnosticSeverity.Warning,
+			_          => d => d.Severity >= DiagnosticSeverity.Warning
+		};
+
 		string[] results = [..
 			diagnostics
-				.Where(d => d.Severity >= DiagnosticSeverity.Warning)
+				.Where(severityFilter)
 				.OrderByDescending(d => d.Severity)
 				.ThenBy(d => d.Location.SourceTree?.FilePath)
 				.ThenBy(d => d.Location.GetLineSpan().StartLinePosition.Line)

--- a/src/RoslynMcp/Tools/Analysis/ProjectInfoTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ProjectInfoTool.cs
@@ -22,7 +22,8 @@ internal sealed class ProjectInfoTool : RoslynMcpTool
 		"output kind, nullable setting, NuGet package references, and additional files. " +
 		"Use this to understand project configuration without reading the .csproj directly.")]
 	public object GetProjectInfo(
-		[Description(ProjectPathDescription)] string projectPath)
+		[Description(ProjectPathDescription)] string projectPath,
+		[Description("When true, only returns direct package references from the .csproj (not transitive). Default: true.")] bool directOnly = true)
 	{
 		using var scope = BeginTool("roslyn_get_project_info");
 		if(!TryGetProject(projectPath, out var project, out var error))
@@ -38,7 +39,10 @@ internal sealed class ProjectInfoTool : RoslynMcpTool
 		var outputKind   = compOpts?.OutputKind.ToString() ?? "Unknown";
 		var nullable     = compOpts?.NullableContextOptions.ToString() ?? "Unknown";
 		var langVersion  = parseOpts?.LanguageVersion.ToDisplayString() ?? "Unknown";
-		var packages     = ExtractPackages(project.MetadataReferences);
+		var packages     = directOnly && project.FilePath is not null
+			? ExtractDirectPackages(project.FilePath)
+			: ExtractPackages(project.MetadataReferences)
+		;
 		string[] extraFiles = [..
 			project.AdditionalDocuments
 				.Select(d => Path.GetRelativePath(rootPath, d.FilePath ?? d.Name))
@@ -110,5 +114,27 @@ internal sealed class ProjectInfoTool : RoslynMcpTool
 		];
 	}
 	
+	private static PackageRef[] ExtractDirectPackages(string csprojPath)
+	{
+		try {
+
+			var doc = System.Xml.Linq.XDocument.Load(csprojPath);
+
+			return [..
+				doc.Descendants("PackageReference")
+					.Select(e => new PackageRef(
+						e.Attribute("Include")?.Value ?? "?",
+						e.Attribute("Version")?.Value ?? "*"
+					))
+					.DistinctBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+					.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+			];
+		}
+		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException or System.Xml.XmlException) {
+
+			return [];
+		}
+	}
+
 	private sealed record PackageRef(string Name, string Version);
 }

--- a/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
@@ -1,6 +1,5 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using ModelContextProtocol.Server;
 
@@ -10,12 +9,12 @@ namespace RoslynMcp.Tools;
 internal sealed class SymbolInfoTool : RoslynMcpTool
 {
 	public SymbolInfoTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
-	
+
 	[McpServerTool(Name = "roslyn_get_symbol_info", ReadOnly = true)]
 	[Description(
-		"Returns resolved symbol information at a specific file location — type, kind, containing type, return type. " +
+		"Returns resolved symbol information at a specific file location — kind, name, containing type, return type. " +
 		"Use to verify what a name resolves to without reading the full file.")]
-	public async Task<string> GetSymbolInfo(
+	public async Task<object> GetSymbolInfo(
 		[Description("Relative file path, e.g. 'Core/WindowTracker.cs'.")] string filePath,
 		[Description("1-based line number.")] int line,
 		[Description("1-based column number.")] int column,
@@ -23,76 +22,65 @@ internal sealed class SymbolInfoTool : RoslynMcpTool
 	{
 		using var scope = BeginTool("roslyn_get_symbol_info", $"{filePath}:{line}");
 		if(!TryGetCompilation(projectPath, out var compilation, out var error))
-			return error.ToString()!;
-		
-		
-		var normalized  = filePath.Replace('/', Path.DirectorySeparatorChar);
-		
-		var tree = compilation.SyntaxTrees
-			.FirstOrDefault(t => t.FilePath.EndsWith(normalized, StringComparison.OrdinalIgnoreCase))
-		;
-		
+			return error;
+
+		var tree = FindSyntaxTree(compilation, filePath);
+
 		if(tree is null)
-			return scope.Failed("file not found", $"File '{filePath}' not found in the compilation.");
-		
+			return scope.Failed("file not found", new { error = $"File '{filePath}' not found in the compilation." });
+
 		var text     = await tree.GetTextAsync();
 		var position = GetPosition(text, line, column);
-		
+
 		if(position < 0)
-			return $"Line {line}, column {column} is out of range.";
-		
+			return new { error = $"Line {line}, column {column} is out of range." };
+
 		var model = compilation.GetSemanticModel(tree);
 		var node  = (await tree.GetRootAsync()).FindToken(position).Parent;
-		
+
 		if(node is null)
-			return "No node at that position.";
-		
+			return new { error = "No node at that position." };
+
 		var info   = model.GetSymbolInfo(node);
 		var symbol = info.Symbol ?? info.CandidateSymbols.FirstOrDefault();
-		
+
 		if(symbol is null) {
-			// Try type info — might be a type expression rather than a symbol reference.
+
 			var typeInfo = model.GetTypeInfo(node);
-			
+
 			if(typeInfo.Type is not null)
-				return $"Type: {typeInfo.Type.ToDisplayString()}";
-			
-			return "No symbol resolved at that position.";
+				return new {
+					kind = "type",
+					name = typeInfo.Type.ToDisplayString(),
+					containing_type = (string?) null,
+					type_or_return  = (string?) null
+				};
+
+			return new { error = "No symbol resolved at that position." };
 		}
-		
-		return FormatSymbol(symbol);
+
+		return new {
+			kind            = symbol.Kind.ToString().ToLowerInvariant(),
+			name            = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+			containing_type = symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+			type_or_return  = symbol switch {
+				IMethodSymbol   m => m.ReturnType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+				IPropertySymbol p => p.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+				IFieldSymbol    f => f.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+				ILocalSymbol    l => l.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+				_                 => (string?) null
+			},
+			_caution = AdhocCaution(projectPath)
+		};
 	}
-	
+
 	private static int GetPosition(SourceText text, int line, int column)
 	{
 		if(line < 1 || line > text.Lines.Count)
 			return -1;
-		
+
 		var lineSpan = text.Lines[line - 1];
-		
+
 		return lineSpan.Start + Math.Min(column - 1, lineSpan.Span.Length);
-	}
-	
-	private static string FormatSymbol(ISymbol symbol)
-	{
-		var kind        = symbol.Kind.ToString();
-		var name        = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-		var containing  = symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-		var returnType  = symbol switch {
-			IMethodSymbol   m => m.ReturnType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-			IPropertySymbol p => p.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-			IFieldSymbol    f => f.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-			ILocalSymbol    l => l.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-			_                 => null
-		};
-		
-		var parts = new List<string> { $"Kind: {kind}", $"Name: {name}" };
-		
-		if(containing is not null)
-			parts.Add($"ContainingType: {containing}");
-		if(returnType  is not null)
-			parts.Add($"Type/ReturnType: {returnType}");
-		
-		return string.Join("  |  ", parts);
 	}
 }

--- a/src/RoslynMcp/Tools/Analysis/TypeMembersTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/TypeMembersTool.cs
@@ -24,6 +24,8 @@ internal sealed class TypeMembersTool : RoslynMcpTool
 		[Description("Optional filter: 'field', 'property', 'method', 'enum', 'event', or omit for all.")]
 		string? memberKind = null,
 
+		[Description("Include inherited members from base types. Default: false (declared only).")] bool includeInherited = false,
+
 		[Description("Number of members to skip (for paging). Default: 0.")] int skip = 0,
 		[Description("Maximum number of members to return. Default: 50, max: 200.")] int take = 50,
 		[Description("Token from a previous response to get the next page without re-executing the query.")] string? page_token = null)
@@ -44,8 +46,22 @@ internal sealed class TypeMembersTool : RoslynMcpTool
 		if(type is null)
 			return scope.Failed("type not found", new { error = $"Type '{typeName}' not found in the project." });
 		
+		IEnumerable<ISymbol> members = type.GetMembers();
+
+		if(includeInherited) {
+
+			// Walk the base type chain and collect inherited members.
+			var current = type.BaseType;
+
+			while(current is not null && current.SpecialType != SpecialType.System_Object) {
+
+				members = members.Concat(current.GetMembers());
+				current = current.BaseType;
+			}
+		}
+
 		var allMembers = (object?[]) [..
-			type.GetMembers()
+			members
 				.Where(m => !m.IsImplicitlyDeclared)
 				.Where(m => memberKind is null || MatchesKind(m, memberKind))
 				.Select(FormatMember)

--- a/src/RoslynMcp/Tools/Search/SemanticSearchTool.cs
+++ b/src/RoslynMcp/Tools/Search/SemanticSearchTool.cs
@@ -39,6 +39,9 @@ internal sealed class SemanticSearchTool : RoslynMcpTool
 		
 		[Description("File glob pattern (e.g., '*.cs'). Default: '*.cs'.")]
 		string? filePattern = null,
+
+		[Description("Only match within nodes of this syntax kind (e.g., 'MethodDeclaration', 'ClassDeclaration', 'IfStatement'). Omit to search everywhere.")]
+		string? containingKind = null,
 		
 		[Description("Number of results to skip (for paging). Default: 0.")]
 		int skip = 0,
@@ -139,11 +142,30 @@ internal sealed class SemanticSearchTool : RoslynMcpTool
 					_			  => Array.Empty<SemanticMatchResult>()
 				};
 				
-				// Add file path to each match
+				// Filter by containing syntax kind if specified.
+				if(containingKind is not null && Enum.TryParse<SyntaxKind>(containingKind, ignoreCase: true, out var requiredKind)) {
+
+					matches = matches.Where(m => {
+
+						var pos  = text.Lines[m.Line - 1].Start;
+						var node = root.FindToken(pos).Parent;
+
+						while(node is not null) {
+
+							if(node.IsKind(requiredKind))
+								return true;
+
+							node = node.Parent;
+						}
+
+						return false;
+					});
+				}
+
 				var relativePath = Path.GetRelativePath(rootPath, document.FilePath);
-				
+
 				foreach(var match in matches) {
-				
+
 					match.File = relativePath;
 					allMatches.Add(match);
 				}

--- a/src/TestHarness/Program.cs
+++ b/src/TestHarness/Program.cs
@@ -263,8 +263,7 @@ tests.Add(await RunTestAsync(
 	"roslyn_get_symbol_info: resolve symbol at location",
 	"roslyn_get_symbol_info",
 	new { filePath = "Program.cs", line = 10, column = 10, projectPath = targetPath },
-	data => data?.GetValue<string>().Contains("Kind:") == true,
-	expectJson: false
+	data => data?["kind"] is not null && data?["name"] is not null
 ));
 
 tests.Add(await RunTestAsync(


### PR DESCRIPTION
## Summary

Five enhancements to existing tools — each adds a parameter that makes the tool more useful for agents:

1. **`get_diagnostics`** — `severity` filter: `'errors'`, `'warnings'`, or `'all'`
2. **`get_symbol_info`** — returns structured JSON (`{kind, name, containing_type, type_or_return}`) instead of pipe-delimited string. Breaking change from `Task<string>` → `Task<object>`.
3. **`get_project_info`** — `directOnly` parameter (default `true`): parses `.csproj` for `<PackageReference>` instead of dumping 50+ transitive packages from metadata references
4. **`get_type_members`** — `includeInherited` parameter: walks base type chain to include inherited members (excludes `System.Object`)
5. **`semantic_search`** — `containingKind` filter: only match within nodes of a specific syntax kind (e.g., `MethodDeclaration`, `ClassDeclaration`, `IfStatement`)

Fixes #30

## Test plan

- [x] 31/31 test harness passing
- [ ] `get_diagnostics` with `severity: "errors"` — verify only errors returned
- [ ] `get_symbol_info` — verify JSON response with `kind`, `name` fields
- [ ] `get_project_info` with `directOnly: true` — verify only direct packages
- [ ] `get_type_members` with `includeInherited: true` — verify base type members included
- [ ] `semantic_search` with `containingKind: "MethodDeclaration"` — verify matches are within methods only

🤖 Generated with [Claude Code](https://claude.com/claude-code)