### PR TITLE
feat: add roslyn_change_signature + apply_signature_change tools

### DIFF
--- a/src/RoslynMcp/Tools/Refactoring/ApplySignatureChangeTool.cs
+++ b/src/RoslynMcp/Tools/Refactoring/ApplySignatureChangeTool.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Tools;
+
+[McpServerToolType]
+internal sealed class ApplySignatureChangeTool : RoslynMcpTool
+{
+	readonly ApprovalStore approvals;
+
+	public ApplySignatureChangeTool(WorkspaceResolver workspace, ApprovalStore approvals, FileLogger logger, PaginationCache paginationCache)
+		: base(workspace, logger, paginationCache)
+	{
+		this.approvals = approvals;
+	}
+
+	[McpServerTool(Name = "roslyn_apply_signature_change", Destructive = true)]
+	[Description(
+		"Applies or rejects a signature change previewed by change_signature. " +
+		"approval: 'y' = apply once, 'session' = apply and auto-approve this method for the session, 'n' = reject.")]
+	public async Task<string> ApplySignatureChange(
+		[Description("The confirmation token returned by change_signature.")] string token,
+		[Description("'y' to apply, 'session' to apply and remember, 'n' to reject.")] string approval,
+		[Description(ProjectPathDescription)] string projectPath)
+	{
+		using var scope = BeginTool("roslyn_apply_signature_change", token);
+
+		if(approval.Equals("n", StringComparison.OrdinalIgnoreCase)) {
+
+			approvals.Reject(token);
+			return scope.Failed("rejected", "Signature change rejected. No files were changed.");
+		}
+
+		if(!approval.Equals("y", StringComparison.OrdinalIgnoreCase)
+			&& !approval.Equals("session", StringComparison.OrdinalIgnoreCase))
+			return "Invalid approval value. Use 'y', 'session', or 'n'.";
+
+		var forSession = approval.Equals("session", StringComparison.OrdinalIgnoreCase);
+		var op         = approvals.Consume(token, forSession);
+
+		if(op is null)
+			return scope.Failed("token not found", $"Token '{token}' not found or already consumed. Run change_signature again.");
+
+		await SolutionDiff.ApplyToDiskAsync(op.BaseSolution, op.NewSolution);
+
+		var filesChanged = op.NewSolution.GetChanges(op.BaseSolution)
+			.GetProjectChanges()
+			.SelectMany(p => p.GetChangedDocuments())
+			.Count()
+		;
+
+		var sessionNote = forSession ? " Method approved for the remainder of this session." : string.Empty;
+
+		return scope.Outcome($"{filesChanged} file(s) written", $"Signature change applied.{sessionNote} Files written to disk.");
+	}
+}

--- a/src/RoslynMcp/Tools/Refactoring/ChangeSignatureTool.cs
+++ b/src/RoslynMcp/Tools/Refactoring/ChangeSignatureTool.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using ModelContextProtocol.Server;
+using RoslynMcp.Tools.SignatureChange;
+
+namespace RoslynMcp.Tools;
+
+/// <summary>
+///     Thin MCP entry point for signature changes. Validates input, delegates to
+///     <see cref="SignatureChangeOrchestrator"/>, and manages the preview/apply token workflow.
+///     See docs/plans/change-signature-tool.md for full design.
+/// </summary>
+[McpServerToolType]
+internal sealed class ChangeSignatureTool : RoslynMcpTool
+{
+	readonly ApprovalStore approvals;
+
+	public ChangeSignatureTool(WorkspaceResolver workspace, ApprovalStore approvals, FileLogger logger, PaginationCache paginationCache)
+		: base(workspace, logger, paginationCache)
+	{
+		this.approvals = approvals;
+	}
+
+	[McpServerTool(Name = "roslyn_change_signature", Destructive = true)]
+	[Description(
+		"Changes a method signature by adding parameters. Creates a non-breaking forwarding overload " +
+		"with [Obsolete] attribute so existing call sites continue to work. " +
+		"Returns a unified diff and confirmation token. Pass the token to apply_signature_change to commit.")]
+	public async Task<object> ChangeSignature(
+		[Description("Method name to change, e.g. 'ProcessOrder'.")] string methodName,
+		[Description(ProjectPathDescription)] string projectPath,
+		[Description("Optional containing type, e.g. 'OrderService'.")] string? containingType = null,
+		[Description("Parameters to add as JSON array: [{\"name\":\"x\",\"type\":\"string\",\"defaultValue\":\"\\\"default\\\"\"}]")] string? addParameters = null)
+	{
+		using var scope = BeginTool("roslyn_change_signature", $"{containingType}.{methodName}");
+
+		if(!TryGetCompilation(projectPath, out var compilation, out var error))
+			return error;
+
+		var symbol = FindSymbol(compilation, methodName, containingType);
+
+		if(symbol is not IMethodSymbol method)
+			return scope.Failed("not a method", new {
+				error = symbol is null
+					? $"Symbol '{methodName}' not found."
+					: $"'{methodName}' is a {symbol.Kind}, not a method."
+			});
+
+		// Parse the parameters to add.
+		NewParameter[] paramsToAdd;
+
+		try {
+
+			paramsToAdd = string.IsNullOrWhiteSpace(addParameters)
+				? []
+				: JsonSerializer.Deserialize<NewParameter[]>(addParameters, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? []
+			;
+		}
+		catch(JsonException ex) {
+
+			return scope.Failed("invalid parameters", new {
+				error   = "Failed to parse addParameters JSON.",
+				details = ex.Message,
+				hint    = "Expected: [{\"name\":\"x\",\"type\":\"string\",\"defaultValue\":\"\\\"default\\\"\"}]"
+			});
+		}
+
+		// Delegate to orchestrator.
+		var orchestrator = new SignatureChangeOrchestrator();
+		var solution     = workspace.GetSolution(projectPath);
+
+		var result = await orchestrator.PrepareAsync(method, new SignatureChangeRequest {
+			AddParameters = paramsToAdd
+		}, solution, compilation);
+
+		if(!result.Success)
+			return scope.Failed("change failed", new { error = result.Error });
+
+		var token = approvals.Register(result.BaseSolution, result.NewSolution, result.Diff!,
+			$"{method.ContainingType?.ToDisplayString()}::{method.Name}({string.Join(",", method.Parameters.Select(p => p.Type.ToDisplayString()))})"
+		);
+
+		return scope.Outcome($"{result.ParametersAdded.Length} parameter(s) added", new {
+			diff                = result.Diff,
+			token,
+			message             = $"Review the diff, then call apply_signature_change with token '{token}' and approval 'y' or 'session'.",
+			parameters_added    = result.ParametersAdded,
+			deprecation_message = result.DeprecationMessage,
+			files_affected      = result.FilesAffected,
+			_caution            = AdhocCaution(projectPath)
+		});
+	}
+}

--- a/src/RoslynMcp/Tools/Refactoring/SignatureChange/AddParameterEditor.cs
+++ b/src/RoslynMcp/Tools/Refactoring/SignatureChange/AddParameterEditor.cs
@@ -1,0 +1,127 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Tools.SignatureChange;
+
+/// <summary>
+///     Phase 1 editor: adds parameters to a method in non-breaking mode.
+///     Creates a forwarding overload with [Obsolete] attribute so existing
+///     call sites continue to work without modification.
+/// </summary>
+internal sealed class AddParameterEditor : SignatureEditor
+{
+	public override bool CanHandle(IMethodSymbol method)
+		=> method.MethodKind == MethodKind.Ordinary && !method.IsExtern;
+
+	public override string? Validate(IMethodSymbol method, SignatureChangeRequest request)
+	{
+		if(request.AddParameters.Length == 0)
+			return "No parameters to add.";
+
+		if(method.IsAbstract)
+			return "Cannot add parameters to abstract methods — override chain would break.";
+
+		// Check for name collisions with existing parameters.
+		var existingNames = method.Parameters.Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+
+		foreach(var p in request.AddParameters) {
+
+			if(existingNames.Contains(p.Name))
+				return $"Parameter '{p.Name}' already exists on '{method.Name}'.";
+		}
+
+		return null;
+	}
+
+	public override async Task<SignatureChangeResult> ApplyAsync(
+		IMethodSymbol method,
+		MethodDeclarationSyntax declaration,
+		SignatureChangeRequest request,
+		Solution solution,
+		Compilation compilation)
+	{
+		// Build the new parameter list (existing + added).
+		var newParams = new List<ParameterSyntax>(declaration.ParameterList.Parameters);
+
+		foreach(var p in request.AddParameters) {
+
+			var param = SyntaxFactory.Parameter(SyntaxFactory.Identifier(p.Name))
+				.WithType(SyntaxFactory.ParseTypeName(p.Type + " "))
+			;
+
+			if(p.DefaultValue is not null)
+				param = param.WithDefault(SyntaxFactory.EqualsValueClause(SyntaxFactory.ParseExpression(p.DefaultValue)));
+
+			newParams.Add(param);
+		}
+
+		var updatedMethod = declaration.WithParameterList(
+			SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(newParams))
+		);
+
+		// Build the forwarding overload (old signature → calls new method with defaults).
+		var forwardingArgs = new List<ArgumentSyntax>();
+
+		foreach(var existingParam in declaration.ParameterList.Parameters)
+			forwardingArgs.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(existingParam.Identifier)));
+
+		foreach(var p in request.AddParameters)
+			forwardingArgs.Add(SyntaxFactory.Argument(SyntaxFactory.ParseExpression(p.DefaultValue ?? "default")));
+
+		var forwardingCall = SyntaxFactory.InvocationExpression(
+			SyntaxFactory.IdentifierName(method.Name),
+			SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(forwardingArgs))
+		);
+
+		var forwardingBody = method.ReturnsVoid
+			? (StatementSyntax) SyntaxFactory.ExpressionStatement(forwardingCall)
+			: SyntaxFactory.ReturnStatement(forwardingCall)
+		;
+
+		var deprecationMessage = $"Use {method.Name}({string.Join(", ", newParams.Select(p => p.Type?.ToString().Trim()))}) instead.";
+
+		var obsoleteAttr = SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(
+			SyntaxFactory.Attribute(
+				SyntaxFactory.ParseName("System.Obsolete"),
+				SyntaxFactory.AttributeArgumentList(SyntaxFactory.SingletonSeparatedList(
+					SyntaxFactory.AttributeArgument(SyntaxFactory.LiteralExpression(
+						SyntaxKind.StringLiteralExpression,
+						SyntaxFactory.Literal(deprecationMessage)
+					))
+				))
+			)
+		));
+
+		var forwardingMethod = declaration
+			.WithAttributeLists(declaration.AttributeLists.Add(obsoleteAttr))
+			.WithBody(SyntaxFactory.Block(forwardingBody))
+			.WithExpressionBody(null)
+			.WithSemicolonToken(default)
+		;
+
+		// Apply to the syntax tree.
+		var tree    = declaration.SyntaxTree;
+		var root    = await tree.GetRootAsync();
+		var newRoot = root.ReplaceNode(declaration, new SyntaxNode[] { updatedMethod, forwardingMethod });
+
+		var docId = solution.GetDocumentIdsWithFilePath(tree.FilePath).FirstOrDefault();
+
+		if(docId is null)
+			return SignatureChangeResult.Failed(solution, "Could not resolve document in solution.");
+
+		var newSolution = solution.WithDocumentSyntaxRoot(docId, newRoot);
+		var diff        = await SolutionDiff.BuildAsync(solution, newSolution);
+
+		return new SignatureChangeResult {
+
+			Success            = true,
+			BaseSolution       = solution,
+			NewSolution        = newSolution,
+			Diff               = diff,
+			ParametersAdded    = [.. request.AddParameters.Select(p => $"{p.Type} {p.Name}")],
+			DeprecationMessage = deprecationMessage,
+			FilesAffected      = 1
+		};
+	}
+}

--- a/src/RoslynMcp/Tools/Refactoring/SignatureChange/SignatureChangeOrchestrator.cs
+++ b/src/RoslynMcp/Tools/Refactoring/SignatureChange/SignatureChangeOrchestrator.cs
@@ -1,0 +1,53 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Tools.SignatureChange;
+
+/// <summary>
+///     Coordinates signature changes: validates the request, selects the appropriate
+///     <see cref="SignatureEditor"/>, and delegates the transformation.
+///     Decoupled from MCP protocol — the tool class handles tokens, diffs, and approval.
+/// </summary>
+internal sealed class SignatureChangeOrchestrator
+{
+	// Editors are tried in order — first one that CanHandle wins.
+	// Phase 2 adds RemoveParameterEditor, BreakingModeEditor, etc.
+	static readonly SignatureEditor[] Editors = [
+		new AddParameterEditor()
+	];
+
+	public async Task<SignatureChangeResult> PrepareAsync(
+		IMethodSymbol method,
+		SignatureChangeRequest request,
+		Solution solution,
+		Compilation compilation)
+	{
+		// Find an editor that can handle this method kind.
+		var editor = Editors.FirstOrDefault(e => e.CanHandle(method));
+
+		if(editor is null)
+			return SignatureChangeResult.Failed(solution,
+				$"No editor available for {method.MethodKind} method '{method.Name}'."
+			);
+
+		// Validate the request against the method.
+		var validationError = editor.Validate(method, request);
+
+		if(validationError is not null)
+			return SignatureChangeResult.Failed(solution, validationError);
+
+		// Find the declaration syntax.
+		var declRef = method.DeclaringSyntaxReferences.FirstOrDefault();
+
+		if(declRef is null)
+			return SignatureChangeResult.Failed(solution, "Method is defined in metadata, not source.");
+
+		var declaration = await declRef.GetSyntaxAsync() as MethodDeclarationSyntax;
+
+		if(declaration is null)
+			return SignatureChangeResult.Failed(solution, "Symbol resolves to a non-method syntax node.");
+
+		// Delegate to the editor.
+		return await editor.ApplyAsync(method, declaration, request, solution, compilation);
+	}
+}

--- a/src/RoslynMcp/Tools/Refactoring/SignatureChange/SignatureChangeResult.cs
+++ b/src/RoslynMcp/Tools/Refactoring/SignatureChange/SignatureChangeResult.cs
@@ -1,0 +1,30 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Tools.SignatureChange;
+
+/// <summary>
+///     The output of a signature change preparation. Contains the new solution,
+///     diff, diagnostics, and summary — regardless of which editor produced it.
+/// </summary>
+internal sealed record SignatureChangeResult
+{
+	public required bool     Success       { get; init; }
+	public required Solution BaseSolution  { get; init; }
+	public required Solution NewSolution   { get; init; }
+	public string?           Error         { get; init; }
+	public string?           Diff          { get; init; }
+	public string[]          Warnings      { get; init; } = [];
+	public string[]          ParametersAdded   { get; init; } = [];
+	public string[]          ParametersRemoved { get; init; } = [];
+	public string?           DeprecationMessage { get; init; }
+	public int               CallSitesUpdated  { get; init; }
+	public int               FilesAffected     { get; init; }
+
+	public static SignatureChangeResult Failed(Solution solution, string error) => new() {
+
+		Success      = false,
+		BaseSolution = solution,
+		NewSolution  = solution,
+		Error        = error
+	};
+}

--- a/src/RoslynMcp/Tools/Refactoring/SignatureChange/SignatureEditor.cs
+++ b/src/RoslynMcp/Tools/Refactoring/SignatureChange/SignatureEditor.cs
@@ -1,0 +1,48 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Tools.SignatureChange;
+
+/// <summary>
+///     Base class for signature editors. Each subclass handles a specific method kind
+///     (regular, extern, operator, constructor, indexer). Phase 1 implements only
+///     <see cref="AddParameterEditor"/>. Future editors slot in without changing the
+///     orchestrator or tool class.
+/// </summary>
+internal abstract class SignatureEditor
+{
+	/// <summary>Can this editor handle the given method symbol?</summary>
+	public abstract bool CanHandle(IMethodSymbol method);
+
+	/// <summary>
+	///     Validates that the requested change is safe for this method kind.
+	///     Returns null if valid, or an error message if not.
+	/// </summary>
+	public abstract string? Validate(IMethodSymbol method, SignatureChangeRequest request);
+
+	/// <summary>
+	///     Produces a new solution with the signature change applied.
+	///     Does not write to disk — the orchestrator handles that.
+	/// </summary>
+	public abstract Task<SignatureChangeResult> ApplyAsync(
+		IMethodSymbol method,
+		MethodDeclarationSyntax declaration,
+		SignatureChangeRequest request,
+		Solution solution,
+		Compilation compilation);
+}
+
+/// <summary>
+///     Describes what changes to make to a method signature.
+///     Extensible: Phase 2 adds RemoveParameters, ReorderParameters, BreakingMode.
+/// </summary>
+internal sealed record SignatureChangeRequest
+{
+	public NewParameter[] AddParameters    { get; init; } = [];
+	// Phase 2:
+	// public string[]?   RemoveParameters   { get; init; }
+	// public Dictionary<int,int>? Reorder   { get; init; }
+	// public bool         BreakingMode      { get; init; }
+}
+
+internal sealed record NewParameter(string Name, string Type, string? DefaultValue);

--- a/src/TestHarness/Program.cs
+++ b/src/TestHarness/Program.cs
@@ -399,7 +399,7 @@ tests.Add(await RunTestAsync(
 	data => data?["succeeded"] is not null && data?["source"] is not null
 ));
 
-Console.WriteLine("\nRefactoring Tools (1 test)");
+Console.WriteLine("\nRefactoring Tools (2 tests)");
 Console.WriteLine("─────────────────────────────────────────────────────────────");
 
 tests.Add(await RunTestAsync(
@@ -407,6 +407,22 @@ tests.Add(await RunTestAsync(
 	"roslyn_preview_rename",
 	new { symbolName = "compilation", newName = "compilation2", containingType = "WorkspaceInstance", projectPath = targetPath },
 	data => (data?["Token"] ?? data?["token"]) is not null || (data?["Message"] ?? data?["message"]) is not null
+));
+
+// Test change_signature against an existing method — temp files aren't visible
+// to MSBuild workspace (new files require server restart).
+tests.Add(await RunTestAsync(
+	"roslyn_change_signature: preview adding parameter",
+	"roslyn_change_signature",
+	new {
+		methodName     = "NormalizePath",
+		containingType = "RoslynMcpTool",
+		addParameters  = "[{\"name\":\"toLower\",\"type\":\"bool\",\"defaultValue\":\"false\"}]",
+		projectPath    = targetPath
+	},
+	data => data?["token"] is not null
+		 && data?["diff"]?.GetValue<string>().Contains("Obsolete") == true
+		 && data?["parameters_added"]?.AsArray().Count == 1
 ));
 
 Console.WriteLine("\nFile Editing Tools (5 tests)");


### PR DESCRIPTION
## Summary

Two new tools for semantic signature refactoring — the last v0.7.0 item.

**`roslyn_change_signature`** — adds parameters to a method in non-breaking mode:
- Creates a forwarding overload with `[Obsolete]` attribute
- Existing call sites continue to work without modification
- Returns a unified diff + confirmation token (same workflow as rename)

**`roslyn_apply_signature_change`** — commits or rejects via token (y/session/n)

### Architecture (Right Code for Phase 2)

```
ChangeSignatureTool (thin MCP entry point)
    ↓
SignatureChangeOrchestrator (validates, selects editor)
    ↓
SignatureEditor (abstract base — strategy pattern)
    ├── AddParameterEditor (Phase 1 — this PR)
    ├── RemoveParameterEditor (Phase 2)
    ├── BreakingModeEditor (Phase 2)
    └── ...
```

Phase 2 adds new editors without changing the tool or orchestrator. The skeleton is intentional — communicates design intent and prevents painting into a corner.

Fixes #7

## Test plan

- [x] 32/32 test harness passing
- [x] change_signature returns token + diff containing `[Obsolete]`
- [ ] Apply the change and verify forwarding overload compiles
- [ ] Test with a method that has existing parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)