### PR TITLE
chore: bump version to 0.7.0-alpha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ When in doubt: **ask, don't assume.** A thirty-second question beats reverting s
 | **Type** | Model Context Protocol (MCP) server — stdio transport |
 | **Runtime** | .NET 8 / .NET 10 (net11.0 auto-added when .NET 11 SDK is detected) |
 | **Language** | C# 14 (`<LangVersion>preview</LangVersion>`) |
-| **Version** | 0.6.0-alpha (pre-1.0) |
+| **Version** | 0.7.0-alpha (pre-1.0) |
 | **Tool Count** | 26 MCP tools (25 stable + 1 experimental) |
 | **Dependencies** | `Microsoft.CodeAnalysis.*` (Roslyn) — MSBuildWorkspace (if .csproj found) → AdhocWorkspace (fallback) |
 | **ImplicitUsings** | `enable` — don't add redundant `using` directives |

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 	<PropertyGroup>
         
-        <VersionPrefix>0.6.0</VersionPrefix>
+        <VersionPrefix>0.7.0</VersionPrefix>
         
         <VersionSuffix>alpha</VersionSuffix>
         


### PR DESCRIPTION
- `Directory.build.props`: 0.6.0 → 0.7.0
- `AGENTS.md`: 0.6.0-alpha → 0.7.0-alpha

Ready for `v0.7.0-alpha` tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)