### PR TITLE
docs: add v0.7.0-alpha changelog section

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ This file contains Copilot-specific overrides and notes only.
 
 **All details in [`AGENTS.md`](../AGENTS.md):**
 - Project overview and architecture
-- All 25 tool descriptions
+- All 28 tool descriptions
 - Code style rules (braces, naming, blank lines, etc.)
 - MCP protocol patterns
 - Roslyn API patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ When in doubt: **ask, don't assume.** A thirty-second question beats reverting s
 | **Runtime** | .NET 8 / .NET 10 (net11.0 auto-added when .NET 11 SDK is detected) |
 | **Language** | C# 14 (`<LangVersion>preview</LangVersion>`) |
 | **Version** | 0.7.0-alpha (pre-1.0) |
-| **Tool Count** | 26 MCP tools (25 stable + 1 experimental) |
+| **Tool Count** | 28 MCP tools (25 stable + 2 refactoring + 1 experimental) |
 | **Dependencies** | `Microsoft.CodeAnalysis.*` (Roslyn) — MSBuildWorkspace (if .csproj found) → AdhocWorkspace (fallback) |
 | **ImplicitUsings** | `enable` — don't add redundant `using` directives |
 | **Resources** | [C# MCP SDK](https://csharp.sdk.modelcontextprotocol.io/) • [MCP Spec](https://modelcontextprotocol.io/) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ Folds in previously unreleased v0.3.0-alpha work (multi-project infrastructure) 
 
 ---
 
-## [0.2.0-alpha] - 2026-01-XX
+## [0.2.0-alpha] - 2026-01-XX (releases removed — broken builds)
 
 ### Added
 - **23 MCP tools** covering all core agent workflows:
@@ -134,7 +134,7 @@ Folds in previously unreleased v0.3.0-alpha work (multi-project infrastructure) 
 
 ---
 
-## [0.1.0-alpha] - 2026-01-XX (Initial Development)
+## [0.1.0-alpha] - 2026-01-XX (Initial Development — release removed)
 
 ### Added
 - Core MCP server infrastructure
@@ -176,9 +176,8 @@ Folds in previously unreleased v0.3.0-alpha work (multi-project infrastructure) 
 
 ---
 
-[Unreleased]: https://github.com/MadQ/RoslynMcp/compare/v0.6.0-alpha...HEAD
+[Unreleased]: https://github.com/MadQ/RoslynMcp/compare/v0.7.0-alpha...HEAD
+[0.7.0-alpha]: https://github.com/MadQ/RoslynMcp/compare/v0.6.0-alpha...v0.7.0-alpha
 [0.6.0-alpha]: https://github.com/MadQ/RoslynMcp/compare/v0.5.0-alpha...v0.6.0-alpha
 [0.5.0-alpha]: https://github.com/MadQ/RoslynMcp/compare/v0.4.0-alpha...v0.5.0-alpha
-[0.4.0-alpha]: https://github.com/MadQ/RoslynMcp/compare/v0.2.0-alpha...v0.4.0-alpha
-[0.2.0-alpha]: https://github.com/MadQ/RoslynMcp/releases/tag/v0.2.0-alpha
-[0.1.0-alpha]: https://github.com/MadQ/RoslynMcp/releases/tag/v0.1.0-alpha
+[0.4.0-alpha]: https://github.com/MadQ/RoslynMcp/releases/tag/v0.4.0-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.0-alpha] — 2026-03-28
+
+### Added
+- **`roslyn_get_member_body`** — returns the full source of a single method/property/field/type by name; handles partial types. The flagship token-reduction tool (#28)
+- **`roslyn_change_signature`** — adds parameters in non-breaking mode with forwarding overload + `[Obsolete]`. Strategy pattern architecture ready for Phase 2 (#7)
+- **`roslyn_apply_signature_change`** — applies or rejects signature changes via token (same workflow as rename)
+- **Token-based pagination cache** — `PaginationCache` with `ReadOnlyMemory<T>` mutation protection, sliding-window 60s TTL. Agents pass `page_token` to get subsequent pages without re-executing the query (#40)
+- **`AllSymbolsFinder`** — finds all symbols matching a name (not just the first), used by `find_references` for complete results
+- **`SymbolFormatter`** — shared static utility for method/property/field/event/type signature formatting
+- **LogViewer overhaul** — keyboard shortcuts (1-6 filters, S, Ctrl+F, Ctrl+L, Esc, Q, ?), search bar with live highlighting, FAIL filter (failed TOOL entries), legend toggle, equal-width buttons
+
+### Changed
+- **`roslyn_list_types`** — without `namespaceFilter`, returns only source-defined types (no more 829K character context-window bomb). Added skip/take/page_token (#29)
+- **`roslyn_find_references`** — without `containingType`, searches ALL matching symbols and unions results. Response includes `symbols_searched` field (#29)
+- **`roslyn_get_diagnostics`** — added `severity` filter ('errors', 'warnings', 'all') (#30)
+- **`roslyn_get_symbol_info`** — returns structured JSON instead of pipe-delimited string (#30)
+- **`roslyn_get_project_info`** — added `directOnly` parameter (default true) for direct NuGet references only (#30)
+- **`roslyn_get_type_members`** — added `includeInherited` parameter for base type members (#30)
+- **`roslyn_semantic_search`** — added `containingKind` filter for syntax-scoped search (#30)
+- **Complete pagination coverage** — `list_files`, `get_trivia`, `list_types` now have skip/take/page_token. All 10 paginated tools wired through `PaginateAndStore`/`TryServeCachedPage`
+- **DRY `Math.Clamp`** — moved into `TryServeCachedPage` with explicit `maxTake` parameter (no defaults)
+- **Log format redesign** — local time (no date), MSB/ADH workspace indicators (no more nullable `---`), tool name without `roslyn_` prefix, separate subject column, `[HIT]`/`[MISS]` cache tags, column-aligned output
+
+### DRY Extractions
+- `FindSymbol` → `RoslynMcpTool` base class (was duplicated 6x)
+- `FormatSymbolName` → `RoslynMcpTool` base class (was duplicated 3x)
+- `FormatModifiers` → `SymbolFormatter` (was duplicated 4x)
+- `FormatMethod`/`FormatProperty`/`FormatField`/`FormatEvent`/`FormatType` → `SymbolFormatter` (was duplicated 3x each)
+- `FindSyntaxTree` → `RoslynMcpTool` base class (normalizes + suffix matches, used by 8+ tools)
+
+### Docs
+- AGENTS.md updated: constructor pattern, rename API, tool tips section, tool count 26
+- README: highlights solution loading, pagination, get_member_body, smart build 17ms, active roadmap
+- `docs/plans/pagination-cache.md` — design doc for token-based pagination
+- `docs/plans/oop-dry-opportunities.md` — 7 refactoring opportunities in 3 phases
+
+---
+
 ## [0.6.0-alpha] — 2026-03-28
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ dotnet build src/RoslynMcp/RoslynMcp.csproj -f net10.0
 ### Running Tests
 
 ```bash
-# Run the comprehensive test suite (27 tests covering all 25 tools)
+# Run the comprehensive test suite (36 tests covering all 28 tools)
 dotnet run --project src/TestHarness/TestHarness.csproj
 ```
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,7 +11,7 @@ Complete setup instructions for all major MCP-compatible AI coding assistants.
 
 > **Configuration reference:** See [Configuration section in README.md](README.md#configuration) for detailed examples and troubleshooting.
 
-> All 25 tools support multi-project workflows via the required `projectPath` parameter. Individual tool calls can target different projects without restarting the server.
+> All 28 tools support multi-project workflows via the required `projectPath` parameter. Individual tool calls can target different projects without restarting the server.
 
 > **Quick start:** Most clients use one of two patterns:
 > - **Workspace config**: `.mcp.json` or similar file in your project root
@@ -344,7 +344,7 @@ RoslynMcp automatically falls back to AdhocWorkspace (source-only mode) if MSBui
 
 ### Multi-project workspaces
 
-All 25 tools require a `projectPath` parameter, enabling multi-project workflows without restarting the server.
+All 28 tools require a `projectPath` parameter, enabling multi-project workflows without restarting the server.
 
 RoslynMcp can analyze multiple projects if they're part of a `.sln` file or linked via `<ProjectReference>`. Point the command-line argument at the solution directory or primary project directory for pre-loading.
 
@@ -398,7 +398,7 @@ For large codebases (>100K LOC), consider:
 
 **Checklist:**
 1. Server process started successfully (check client logs)
-2. MCP session initialized (`tools/list` should return 25 tools)
+2. MCP session initialized (`tools/list` should return 28 tools)
 3. Target directory is correct (check server stderr for `Target: ...`)
 
 ---

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ RoslynMcp fixes all four by keeping a live Roslyn `Compilation` in process, warm
 
 ## Tools
 
-RoslynMcp provides 25 tools for code analysis and manipulation (24 stable + 1 experimental). **All tools work on the in-memory Roslyn compilation** — no external processes or file system dependencies beyond the initial load.
+RoslynMcp provides 28 tools for code analysis and manipulation (25 stable + 2 refactoring + 1 experimental). Most tools work entirely in-process using the Roslyn compilation. Exceptions: `roslyn_build_project` calls `dotnet build`, `roslyn_clean_solution` and `roslyn_restore_packages` call `dotnet clean`/`dotnet restore`.
 
 ### Guiding Your AI Agent
 
@@ -178,7 +178,9 @@ When discovering code:
 - **MSBuildWorkspace** (if `.csproj` found) — full project resolution including NuGet packages, multi-project support, and .NET Framework compatibility. Requires MSBuild on PATH. Startup: 1-2 seconds.
 - **AdhocWorkspace** (fallback) — loads `.cs` files directly without MSBuild. Fast startup (<100 ms), but only resolves types defined in loaded source files.
 
-**Live compilation** — MSBuildWorkspace monitors files via Roslyn's internal mechanisms. AdhocWorkspace uses `FileSystemWatcher` to detect `.cs` changes and invalidates the compilation lazily on the next tool call. Thread-safe via `ReaderWriterLockSlim`.
+**Live compilation** — FileSystemWatcher detects `.cs` changes for both workspace types and invalidates the compilation on the next tool call. Thread-safe via `ReaderWriterLockSlim`.
+
+**See [Workspace Modes Reference](docs/reference/WORKSPACE_MODES.md) for detailed comparison, troubleshooting, and FAQ.**
 
 **stdio transport** — the MCP protocol runs over stdin/stdout. All logging is suppressed or redirected to stderr so it never corrupts the protocol stream.
 
@@ -221,15 +223,6 @@ Add to `.mcp.json` at your workspace root:
 ```
 
 ---
-
-## Workspace Modes
-
-RoslynMcp automatically selects the best workspace mode for your project:
-
-- **MSBuildWorkspace** (when `.csproj` found) — Full NuGet resolution, multi-project support, .NET Framework 4.6.1+ compatibility. Startup: 1-2 seconds.
-- **AdhocWorkspace** (fallback) — Fast startup (<100 ms), source-only type resolution. Perfect for scripts or demos without project files.
-
-**See [Workspace Modes Reference](docs/reference/WORKSPACE_MODES.md) for detailed comparison, troubleshooting, and FAQ.**
 
 ---
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -378,4 +378,4 @@ If none of the above solutions work:
 
 ---
 
-**Last Updated:** 2025-01-XX (v0.3.0)
+**Last Updated:** 2026-03-28 (v0.7.0-alpha)

--- a/docs/process/DOC_REVIEW_CHECKLIST.md
+++ b/docs/process/DOC_REVIEW_CHECKLIST.md
@@ -34,7 +34,7 @@ rg "RoslynMcp/RoslynMcp\.csproj" --type md --glob "!HANDOFF*.md"
 # 2. Check for dotnet run in MCP configs (should use published executable)
 rg "dotnet.*run.*--project.*\.mcp\.json" --type md -A 3 -B 3
 
-# 3. Verify tool count is consistent (should be 25 tools currently)
+# 3. Verify tool count is consistent (should be 28 tools currently)
 rg "23 tools|22 tools|21 tools" --type md
 
 # 4. Check for stale "deferred" or "planned" features that shipped
@@ -64,7 +64,7 @@ rg "TestHarness/TestHarness\.csproj" --type md | rg -v "src/TestHarness"
   - [ ] AGENTS.md
   - [ ] `docs/sessions/HANDOFF.md` header
   - [ ] TestHarness header comment
-- [ ] Architecture tables list all 25 tools consistently
+- [ ] Architecture tables list all 28 tools consistently
 - [ ] New tools added to all relevant docs
 
 ### Code Examples
@@ -112,7 +112,7 @@ rg "TestHarness/TestHarness\.csproj" --type md | rg -v "src/TestHarness"
 - [ ] Examples are copy-paste ready
 
 ### AGENTS.md
-- [ ] Architecture table has all 25 tools
+- [ ] Architecture table has all 28 tools
 - [ ] Code style rules are current
 - [ ] MCP/Roslyn patterns are accurate
 - [ ] Testing section references correct paths

--- a/docs/reference/WORKSPACE_MODES.md
+++ b/docs/reference/WORKSPACE_MODES.md
@@ -146,7 +146,7 @@ You don't manually "switch" modes—RoslynMcp detects the mode per project path.
 
 ### Multi-Project Workflows (v0.3.0+)
 
-All 25 tools require a `projectPath` parameter, so you can work with **both modes in a single session**:
+All 28 tools require a `projectPath` parameter, so you can work with **both modes in a single session**:
 
 ```json
 // Example: workspace with both project types
@@ -217,14 +217,15 @@ var project = workspace.AddProject("MyProject", LanguageNames.CSharp);
 - Uses `FileSystemWatcher` for change detection
 - No external dependency resolution
 
-### WorkspaceManager (v0.3.0)
+### WorkspaceManager
 
-RoslynMcp's `WorkspaceManager` caches workspace instances using an LRU (Least Recently Used) strategy:
+RoslynMcp's `WorkspaceManager` (split into `WorkspaceManager.cs`, `.Resolution.cs`, `.Instance.cs`) loads the full solution when a `.sln`/`.slnx` is found, and caches workspace instances with LRU eviction:
 
-- **Cache key:** Resolved absolute path to project/directory
-- **Cache size:** Unlimited (relies on GC for cleanup)
-- **Thread-safety:** `ReaderWriterLockSlim` for concurrent access
-- **Invalidation:** Automatic via `FileSystemWatcher` + manual via `InvalidateFile()`
+- **Cache key:** Solution path (or .csproj/directory if no solution found)
+- **Cache size:** Configurable via `ROSLYNMCP_MAX_CACHED_WORKSPACES` (default 5)
+- **Thread-safety:** Lock-free cache lookups; loading outside lock to avoid contention
+- **Invalidation:** FileSystemWatcher (both MSBuild and Adhoc) + manual via `InvalidateFile()`
+- **Per-project compilation cache** — each project in a solution has its own cached compilation
 
 ---
 
@@ -275,4 +276,4 @@ Subsequent calls are instant because the workspace is cached.
 
 ---
 
-**Last Updated:** 2025-01-XX (v0.3.0)
+**Last Updated:** 2026-03-28 (v0.7.0-alpha)

--- a/docs/reference/tools-assessment.md
+++ b/docs/reference/tools-assessment.md
@@ -1,6 +1,6 @@
 # Roslyn MCP Tools: Honest Assessment
 
-> Originally written during v0.3.0 evaluation. Updated with fix status as of v0.6.0-alpha.
+> Originally written during v0.3.0 evaluation. Updated with fix status as of v0.7.0-alpha.
 
 ## Tools That Work Well
 


### PR DESCRIPTION
The deck scrubbers forgot the changelog. 🏴‍☠️

Adds the v0.7.0-alpha section — the largest release entry yet, covering 3 new tools, pagination cache, hardened defaults, filtering parameters, complete pagination coverage, DRY extractions, LogViewer overhaul, and log format redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)