### PR TITLE
feat: add roslyn_insert_lines tool

### DIFF
--- a/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
+++ b/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
@@ -1,0 +1,127 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Tools;
+
+[McpServerToolType]
+internal sealed class InsertLinesTool : RoslynMcpTool
+{
+	public InsertLinesTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache)
+		: base(workspace, logger, paginationCache) { }
+
+	[McpServerTool(Name = "roslyn_insert_lines", Destructive = true)]
+	[Description(
+		"Inserts one or more lines into a file at a specific location. " +
+		"Use this instead of replace_in_file when you need to ADD new lines rather than replace existing content — " +
+		"no need to construct fragile surrounding-context patterns. " +
+		"Specify the insertion point by line number, or by an anchor pattern (insertAfter/insertBefore). " +
+		"The agent controls indentation — lines are inserted exactly as provided."
+	)]
+	public object InsertLines(
+		[Description("Relative path to the file from the workspace root.")                                                ] string  filePath,
+		[Description(ProjectPathDescription)] string projectPath,
+		[Description("The text to insert. May contain newlines for multi-line insertion.")                                 ] string  text,
+		[Description("1-based line number to insert BEFORE. Mutually exclusive with insertAfter/insertBefore.")            ] int?    atLine       = null,
+		[Description("Pattern to match — inserts AFTER the first matching line. Literal string match.")                    ] string? insertAfter  = null,
+		[Description("Pattern to match — inserts BEFORE the first matching line. Literal string match.")                   ] string? insertBefore = null,
+		[Description("Preview the insertion without writing. Returns what would change. Default: false.")                   ] bool    dryRun       = false
+	)
+	{
+		using var scope = BeginTool("roslyn_insert_lines", filePath);
+		var rootPath = workspace.GetRootPath(projectPath);
+		var fullPath = ResolveFilePath(filePath, rootPath);
+
+		if(fullPath is null)
+			return scope.Failed("file not found", new { error = $"File not found: {filePath}" });
+
+		// Exactly one location specifier required.
+		var specCount = (atLine.HasValue ? 1 : 0) + (insertAfter is not null ? 1 : 0) + (insertBefore is not null ? 1 : 0);
+
+		if(specCount == 0)
+			return scope.Failed("no location", new { error = "Specify exactly one of: atLine, insertAfter, or insertBefore." });
+
+		if(specCount > 1)
+			return scope.Failed("multiple locations", new { error = "Specify only one of: atLine, insertAfter, or insertBefore." });
+
+		string[] lines;
+
+		try {
+			lines = File.ReadAllLines(fullPath);
+		}
+		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
+
+			return new {
+				error   = "Failed to read file",
+				details = ex.Message
+			};
+		}
+
+		// Resolve insertion index (0-based, insert BEFORE this index).
+		int insertIndex;
+
+		if(atLine.HasValue) {
+
+			// atLine is 1-based, clamp to valid range [1, lines.Length + 1].
+			insertIndex = Math.Clamp(atLine.Value, 1, lines.Length + 1) - 1;
+		}
+		else if(insertAfter is not null) {
+
+			var matchIndex = Array.FindIndex(lines, l => l.Contains(insertAfter, StringComparison.Ordinal));
+
+			if(matchIndex < 0)
+				return scope.Failed("anchor not found", new { error = $"insertAfter pattern not found: {insertAfter}" });
+
+			insertIndex = matchIndex + 1;
+		}
+		else {
+
+			var matchIndex = Array.FindIndex(lines, l => l.Contains(insertBefore!, StringComparison.Ordinal));
+
+			if(matchIndex < 0)
+				return scope.Failed("anchor not found", new { error = $"insertBefore pattern not found: {insertBefore}" });
+
+			insertIndex = matchIndex;
+		}
+
+		var newLines    = text.Split('\n');
+		var resultLines = new List<string>(lines.Length + newLines.Length);
+
+		resultLines.AddRange(lines[..insertIndex]);
+		resultLines.AddRange(newLines);
+		resultLines.AddRange(lines[insertIndex..]);
+
+		// 1-based line numbers of inserted lines.
+		var insertedLines = Enumerable.Range(insertIndex + 1, newLines.Length).ToArray();
+
+		if(dryRun) {
+
+			return new {
+				applied       = false,
+				insertedAt    = insertIndex + 1,
+				lineCount     = newLines.Length,
+				insertedLines,
+				message       = $"Dry run: {newLines.Length} line(s) would be inserted at line {insertIndex + 1}."
+			};
+		}
+
+		try {
+			File.WriteAllLines(fullPath, resultLines);
+		}
+		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
+
+			return new {
+				error   = "Failed to write file",
+				details = ex.Message
+			};
+		}
+
+		workspace.InvalidateFile(projectPath, fullPath);
+
+		return new {
+			applied       = true,
+			insertedAt    = insertIndex + 1,
+			lineCount     = newLines.Length,
+			insertedLines,
+		};
+	}
+}

--- a/src/TestHarness/TestHarnessProgram.cs
+++ b/src/TestHarness/TestHarnessProgram.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -484,7 +484,7 @@ tests.Add(await RunTestAsync(
 	data => data?["error"]?.GetValue<string>().Contains("already exists") == true
 ));
 
-Console.WriteLine("\nFile Editing Tools (5 tests)");
+Console.WriteLine("\nFile Editing Tools (10 tests)");
 Console.WriteLine("─────────────────────────────────────────────────────────────");
 
 // Create temp files for editing tool tests
@@ -529,6 +529,48 @@ tests.Add(await RunTestAsync(
 	data => data?["error"] is null && data?["applied"] is not null
 ));
 
+
+// ── insert_lines tests ──────────────────────────────────────────────────
+
+var tempInsertFile = Path.Combine(targetPath, ".test_insert_temp.txt");
+await File.WriteAllTextAsync(tempInsertFile, "line one\nline two\nline three\n");
+
+tests.Add(await RunTestAsync(
+	"roslyn_insert_lines: dry run insertAfter",
+	"roslyn_insert_lines",
+	new { filePath = ".test_insert_temp.txt", text = "inserted line", insertAfter = "line one", dryRun = true, projectPath = targetPath },
+	data => data?["applied"]?.GetValue<bool>() == false && data?["insertedAt"]?.GetValue<int>() == 2 && data?["lineCount"]?.GetValue<int>() == 1
+));
+
+tests.Add(await RunTestAsync(
+	"roslyn_insert_lines: apply insertAfter",
+	"roslyn_insert_lines",
+	new { filePath = ".test_insert_temp.txt", text = "after one", insertAfter = "line one", projectPath = targetPath },
+	data => data?["applied"]?.GetValue<bool>() == true && data?["insertedAt"]?.GetValue<int>() == 2
+));
+
+tests.Add(await RunTestAsync(
+	"roslyn_insert_lines: apply insertBefore",
+	"roslyn_insert_lines",
+	new { filePath = ".test_insert_temp.txt", text = "before three", insertBefore = "line three", projectPath = targetPath },
+	data => data?["applied"]?.GetValue<bool>() == true && data?["insertedAt"]?.GetValue<int>() == 4
+));
+
+tests.Add(await RunTestAsync(
+	"roslyn_insert_lines: apply atLine",
+	"roslyn_insert_lines",
+	new { filePath = ".test_insert_temp.txt", text = "at line 1", atLine = 1, projectPath = targetPath },
+	data => data?["applied"]?.GetValue<bool>() == true && data?["insertedAt"]?.GetValue<int>() == 1
+));
+
+tests.Add(await RunTestAsync(
+	"roslyn_insert_lines: error when no location specified",
+	"roslyn_insert_lines",
+	new { filePath = ".test_insert_temp.txt", text = "oops", projectPath = targetPath },
+	data => data?["error"]?.GetValue<string>().Contains("exactly one") == true
+));
+
+try { File.Delete(tempInsertFile); } catch { }
 // Clean up temp files
 try { File.Delete(tempTextFile); } catch { }
 try { File.Delete(tempCodeFile); } catch { }


### PR DESCRIPTION
## Summary
- New `roslyn_insert_lines` tool for inserting lines at a specific file location
- Three positioning modes: `atLine` (1-based line number), `insertAfter` (anchor pattern), `insertBefore` (anchor pattern)
- No auto-indentation — agent provides exact text (KISS)
- Supports `dryRun` for previewing insertions
- Validates exactly one location specifier is provided
- 5 new test harness tests (dry run, insertAfter, insertBefore, atLine, error case)

Closes #72

## Test plan
- [ ] Run test harness — verify all 41 tests pass (36 existing + 5 new)
- [ ] Manual test: insert with `insertAfter` anchor
- [ ] Manual test: insert with `insertBefore` anchor
- [ ] Manual test: insert with `atLine`
- [ ] Verify `dryRun` returns preview without modifying file
- [ ] Verify error when no location specifier provided
- [ ] Verify error when multiple location specifiers provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)