### PR TITLE
chore: add issue template config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/MadQ/RoslynMcp/issues
+    about: Ask questions or share ideas


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/config.yml` so GitHub Community Standards recognizes the existing issue templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)