### PR TITLE
fix: strip UTF-8 BOM from community files + discussions link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: Bug Report
 about: Report a bug or unexpected behavior
 title: "[BUG] "

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discussions
-    url: https://github.com/MadQ/RoslynMcp/issues
+    url: https://github.com/MadQ/RoslynMcp/discussions
     about: Ask questions or share ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: Feature Request
 about: Suggest a new tool or enhancement
 title: "[FEATURE] "

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-﻿# Contributing to RoslynMcp
+# Contributing to RoslynMcp
 
 Thank you for your interest in contributing to RoslynMcp! This document provides guidelines and instructions for contributing.
 


### PR DESCRIPTION
## Summary
- Strip UTF-8 BOM from `bug_report.md`, `feature_request.md`, and `CONTRIBUTING.md` — may be why GitHub Community Standards isn't recognizing the issue templates
- Fix `config.yml` contact link to point to `/discussions` instead of `/issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)