### PR TITLE
docs: complete agent instructions reference + README callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ For Claude Code, create `.mcp.json` in your project root:
 -> Returns just that method's source. 20 lines, not a 600-line file dump.
 ```
 
+> [!IMPORTANT]
+> **Tell your agent to use RoslynMcp.** Agents default to grep and file reads unless you explicitly instruct them. Add a few lines to your project's `CLAUDE.md` or `AGENTS.md` — see [Agent Instructions](#agent-instructions) for a quick example, or [docs/AGENT-INSTRUCTIONS.md](docs/AGENT-INSTRUCTIONS.md) for complete copy-paste instructions covering every tool.
+
 See [INSTALLATION.md](INSTALLATION.md) for setup guides for GitHub Copilot, Claude Desktop, Cursor, Windsurf, Cline, Continue, Roo Code, Zed, and direct CLI usage.
 
 ---
@@ -179,6 +182,8 @@ When working with C# code, prefer roslyn_* MCP tools:
 ### Why this matters
 
 Without explicit instructions, agents default to their built-in file tools. They will grep for symbol names instead of using `roslyn_find_references`. They will read 600-line files instead of calling `roslyn_get_member_body`. The instructions above ensure your agent uses the most accurate tool for the job.
+
+For complete instructions covering every tool, see [docs/AGENT-INSTRUCTIONS.md](docs/AGENT-INSTRUCTIONS.md) — includes both a full version and a compact version.
 
 ---
 

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -1,0 +1,126 @@
+# Agent Instructions for RoslynMcp
+
+Copy the section below into your project's `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, or equivalent agent instruction file. This ensures your AI agent uses RoslynMcp tools instead of falling back to grep, file reads, and text edits.
+
+If your agent still reaches for a built-in tool, ask it *why* it chose that tool instead of the roslyn equivalent. The answer usually reveals a gap in the instructions -- update them with stronger wording. If a tool description is unclear or missing a use case, [open an issue](https://github.com/MadQ/RoslynMcp/issues) or submit a PR.
+
+---
+
+## Copy-Paste Instructions
+
+```markdown
+## RoslynMcp Tool Preferences
+
+ALWAYS prefer roslyn_* MCP tools over built-in tools when working with C# code.
+These tools use the Roslyn compiler for semantic understanding -- they are more
+accurate than grep, Read, or Edit for C# projects. Use them FIRST; fall back to
+built-in tools only if a roslyn tool fails.
+
+### Reading Code
+
+- `roslyn_get_member_body` — Read a single method, property, or type body.
+  Use this INSTEAD OF reading the entire file. Returns only the code you need.
+- `roslyn_read_file` — Read a file from the Roslyn workspace (in-memory, always
+  up-to-date). Use INSTEAD OF Read for .cs files. Also works for non-.cs files
+  (falls back to disk).
+- `roslyn_get_file_outline` — Get the structure of a file (types, members,
+  signatures). Use INSTEAD OF reading a file to understand its layout.
+- `roslyn_get_line_count` — Get line counts for one or more files. Use INSTEAD
+  OF Read + counting lines.
+
+### Discovering Code
+
+- `roslyn_search_files` — Regex search across all files in the project. Use
+  INSTEAD OF Grep for code search within a .NET project.
+- `roslyn_semantic_search` — Search filtered by semantic context: comments,
+  strings, identifiers, XML docs, or code-only. Use when you need to find
+  matches in a specific context (e.g., "TODO" in comments only).
+- `roslyn_list_files` — List files in the project with glob filtering. Use
+  INSTEAD OF Glob for .NET project files.
+- `roslyn_list_types` — List all types in the project, optionally filtered by
+  namespace. Use to discover available types.
+
+### Navigating Symbols
+
+- `roslyn_find_references` — Find all references to a symbol across the entire
+  solution. Use INSTEAD OF Grep for symbol usage search -- it understands
+  overloads, namespaces, and cross-project references.
+- `roslyn_find_implementations` — Find implementations of an interface or
+  overrides of a virtual/abstract method. Grep cannot do this.
+- `roslyn_get_symbol_definition` — Jump to a symbol's declaration. Returns file,
+  line, and the declaration source.
+- `roslyn_get_symbol_info` — Resolve the symbol at a specific file/line/column.
+  Returns type, kind, containing type, and declaration location.
+- `roslyn_get_symbol_documentation` — Get XML documentation for a symbol.
+- `roslyn_get_symbols_in_scope` — List all symbols visible at a specific
+  location. Useful for understanding what's available in a method body.
+
+### Understanding Types
+
+- `roslyn_get_type_members` — List all members of a type with full signatures.
+  Use INSTEAD OF reading the file and scanning for members.
+- `roslyn_get_type_hierarchy` — Show base types, interfaces, and derived types.
+  Grep cannot reliably determine inheritance chains.
+- `roslyn_get_usings` — Extract using directives from a file.
+- `roslyn_get_project_info` — Get project metadata: target framework, packages,
+  project references.
+
+### Editing Code
+
+- `roslyn_replace_in_code` — Syntax-aware find-and-replace. Targets specific
+  node kinds (MethodDeclaration, IdentifierName, etc.) so replacements are
+  precise. Use INSTEAD OF Edit for C# files when you need structural awareness.
+- `roslyn_replace_in_file` — Text-level find-and-replace with regex support.
+  Use for non-C# files or when you need regex. Use INSTEAD OF Edit when
+  replacing patterns across a file.
+- `roslyn_insert_lines` — Insert lines at a specific location (by line number
+  or anchor pattern). Use when ADDING new lines rather than replacing existing
+  content -- no need to construct surrounding-context patterns.
+
+### Refactoring
+
+- `roslyn_preview_rename` — Generate a diff showing what a semantic rename would
+  change across the entire solution. Always preview before applying.
+- `roslyn_apply_rename` — Apply a previously previewed rename. Writes changes to
+  disk across all affected files.
+- `roslyn_change_signature` — Add parameters to a method with automatic
+  forwarding overload generation. Preview before applying.
+- `roslyn_apply_signature_change` — Apply a previously previewed signature
+  change.
+
+### Building and Diagnostics
+
+- `roslyn_build_project` — Smart build: checks Roslyn diagnostics first, only
+  invokes MSBuild if clean. Use INSTEAD OF running `dotnet build` in a terminal.
+  NEVER run `dotnet build` directly.
+- `roslyn_get_diagnostics` — Get compiler errors and warnings without building.
+  Use `severity: "errors"` for fast error-only checks during editing.
+- `roslyn_restore_packages` — Run `dotnet restore`. Use when NuGet packages need
+  updating.
+- `roslyn_clean_solution` — Run `dotnet clean`. Use when build artifacts need
+  clearing.
+```
+
+---
+
+## Compact Version
+
+If the full instructions are too long for your agent's context, use this shorter version:
+
+```markdown
+## RoslynMcp
+
+ALWAYS use roslyn_* tools FIRST for C# code. They use the Roslyn compiler and
+are more accurate than grep/Read/Edit.
+
+- Reading: `roslyn_get_member_body` (single method) > `roslyn_read_file` > Read
+- Structure: `roslyn_get_file_outline` > reading the whole file
+- Search: `roslyn_search_files` / `roslyn_semantic_search` > Grep
+- References: `roslyn_find_references` > Grep (semantic, cross-project)
+- Types: `roslyn_get_type_members` / `roslyn_get_type_hierarchy` > reading files
+- Editing: `roslyn_replace_in_code` (C#) / `roslyn_replace_in_file` (any) > Edit
+- Insert: `roslyn_insert_lines` (by line or anchor) > Edit with context patterns
+- Rename: `roslyn_preview_rename` + `roslyn_apply_rename` > find-and-replace
+- Build: `roslyn_build_project` > NEVER `dotnet build` in terminal
+- Diagnostics: `roslyn_get_diagnostics` for fast error checks
+```


### PR DESCRIPTION
## Summary
- New `docs/AGENT-INSTRUCTIONS.md` — complete copy-paste instructions for all 29 tools, grouped by category (reading, discovery, navigation, types, editing, refactoring, build). Includes both full and compact versions.
- README Quick Start: added `[!IMPORTANT]` callout linking to agent instructions
- README Agent Instructions section: linked to the full reference doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)