### PR TITLE
refactor: result records for paged/editing/refactoring tools (Phase 1b)

### DIFF
--- a/src/RoslynMcp/Tools/Analysis/FileOutlineTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FileOutlineTool.cs
@@ -46,15 +46,15 @@ internal sealed class FileOutlineTool : RoslynMcpTool
 		var allTypes = ExtractTypes(root, model);
 		var result   = PaginateAndStore(allTypes, ref skip, take);
 
-		return scope.Outcome($"{result.Items.Length}/{result.Total} type(s)", new {
-			file        = Path.GetRelativePath(rootPath, tree.FilePath),
-			total_types = result.Total,
-			skip, take,
-			types      = result.Items,
-			page_token = result.PageToken,
-			has_more   = result.HasMore,
-			_caution   = AdhocCaution(projectPath)
-		});
+		return scope.Outcome($"{result.Items.Length}/{result.Total} type(s)", new FileOutlineResult(
+			File:        Path.GetRelativePath(rootPath, tree.FilePath),
+			Total_types: result.Total,
+			Skip: skip, Take: take,
+			Types:      result.Items,
+			Page_token: result.PageToken,
+			Has_more:   result.HasMore,
+			_caution:   AdhocCaution(projectPath)
+		));
 	}
 	
 	private static TypeOutline[] ExtractTypes(SyntaxNode root, SemanticModel model)

--- a/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
@@ -42,9 +42,9 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 		
 		// Handle type symbols (interface or abstract class).
 		if(symbol is INamedTypeSymbol typeSymbol) {
-		
+
 			if(typeSymbol.TypeKind is TypeKind.Interface or TypeKind.Class && typeSymbol.IsAbstract) {
-			
+
 					var impls = await RoslynSymbolFinder.FindImplementationsAsync(typeSymbol, solution);
 				var allResults = impls
 					.OfType<INamedTypeSymbol>()
@@ -52,29 +52,25 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 					.Order()
 					.ToArray()
 				;
-				
+
+				var typeKind = typeSymbol.TypeKind.ToString().ToLowerInvariant();
+				var typeName = typeSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+
 				if(allResults.Length == 0)
-					return new {
-						symbol_type = typeSymbol.TypeKind.ToString().ToLowerInvariant(),
-						symbol_name = typeSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-						total_implementations = 0,
-						skip,
-						take,
-						implementations = new[] { "No implementations found." }
-					};
-				
+					return new FindImplementationsResult(typeKind, typeName, 0, skip, take, ["No implementations found."]);
+
 				var result = PaginateAndStore(allResults, ref skip, take);
 
-				return scope.Outcome($"{result.Items.Length}/{result.Total} implementation(s)", new {
-					symbol_type  = typeSymbol.TypeKind.ToString().ToLowerInvariant(),
-					symbol_name  = typeSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-					total_implementations = result.Total,
-					skip, take,
-					implementations = result.Items,
-					page_token      = result.PageToken,
-					has_more        = result.HasMore,
-					_caution        = AdhocCaution(projectPath)
-				});
+				return scope.Outcome($"{result.Items.Length}/{result.Total} implementation(s)", new FindImplementationsResult(
+					Symbol_type:  typeKind,
+					Symbol_name:  typeName,
+					Total_implementations: result.Total,
+					Skip: skip, Take: take,
+					Implementations: result.Items,
+					Page_token:      result.PageToken,
+					Has_more:        result.HasMore,
+					_caution:        AdhocCaution(projectPath)
+				));
 			}
 			
 			return new ErrorResult($"'{symbolName}' is not an interface or abstract class.");
@@ -82,9 +78,9 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 		
 		// Handle method symbols (abstract or virtual).
 		if(symbol is IMethodSymbol methodSymbol) {
-		
+
 			if(methodSymbol.IsAbstract || methodSymbol.IsVirtual || methodSymbol.IsOverride) {
-			
+
 					var overrides = await RoslynSymbolFinder.FindOverridesAsync(methodSymbol, solution);
 				var allResults = overrides
 					.OfType<IMethodSymbol>()
@@ -92,29 +88,24 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 					.Order()
 					.ToArray()
 				;
-				
+
+				var methodDisplay = FormatMethod(methodSymbol);
+
 				if(allResults.Length == 0)
-					return new {
-						symbol_type = "method",
-						symbol_name = FormatMethod(methodSymbol),
-						total_overrides = 0,
-						skip,
-						take,
-						overrides = new[] { "No overrides found." }
-					};
-				
+					return new FindOverridesResult("method", methodDisplay, 0, skip, take, ["No overrides found."]);
+
 				var result = PaginateAndStore(allResults, ref skip, take);
 
-				return scope.Outcome($"{result.Items.Length}/{result.Total} override(s)", new {
-					symbol_type = "method",
-					symbol_name = FormatMethod(methodSymbol),
-					total_overrides = result.Total,
-					skip, take,
-					overrides  = result.Items,
-					page_token = result.PageToken,
-					has_more   = result.HasMore,
-					_caution  = AdhocCaution(projectPath)
-				});
+				return scope.Outcome($"{result.Items.Length}/{result.Total} override(s)", new FindOverridesResult(
+					Symbol_type: "method",
+					Symbol_name: methodDisplay,
+					Total_overrides: result.Total,
+					Skip: skip, Take: take,
+					Overrides:  result.Items,
+					Page_token: result.PageToken,
+					Has_more:   result.HasMore,
+					_caution:   AdhocCaution(projectPath)
+				));
 			}
 			
 			return new ErrorResult($"'{symbolName}' is not an abstract, virtual, or override method.");

--- a/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindReferencesTool.cs
@@ -83,21 +83,21 @@ internal sealed class FindReferencesTool : RoslynMcpTool
 		;
 
 		if(allResults.Length == 0)
-			return new { total_references = 0, skip, take, references = new[] { $"No references found for '{symbolName}'." } };
+			return new FindReferencesResult(0, [], skip, take, [$"No references found for '{symbolName}'."], "", false, AdhocCaution(projectPath));
 
 		string[] symbolsSearched = [.. symbols.Select(s => FormatSymbolName(s)).Distinct()];
 
 		var result = PaginateAndStore(allResults, ref skip, take);
 
-		return scope.Outcome($"{result.Items.Length}/{result.Total} reference(s) across {symbolsSearched.Length} symbol(s)", new {
-			total_references = result.Total,
-			symbols_searched = symbolsSearched,
-			skip, take,
-			references = result.Items,
-			page_token = result.PageToken,
-			has_more   = result.HasMore,
-			_caution   = AdhocCaution(projectPath)
-		});
+		return scope.Outcome($"{result.Items.Length}/{result.Total} reference(s) across {symbolsSearched.Length} symbol(s)", new FindReferencesResult(
+			Total_references: result.Total,
+			Symbols_searched: symbolsSearched,
+			Skip: skip, Take: take,
+			References: result.Items,
+			Page_token: result.PageToken,
+			Has_more:   result.HasMore,
+			_caution:   AdhocCaution(projectPath)
+		));
 	}
 	
 }

--- a/src/RoslynMcp/Tools/Analysis/GetLineCountTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetLineCountTool.cs
@@ -40,29 +40,29 @@ internal sealed class GetLineCountTool : RoslynMcpTool
 				;
 
 				if(tree is null) {
-					results.Add(new { file = filePath, line_count = (int?) null, error = "not found in compilation" });
+					results.Add(new LineCountEntry(filePath, null, "not found in compilation"));
 					continue;
 				}
 
 				var text = await tree.GetTextAsync();
-				results.Add(new { file = Path.GetRelativePath(rootPath, tree.FilePath), line_count = (int?) text.Lines.Count, error = (string?) null });
+				results.Add(new LineCountEntry(Path.GetRelativePath(rootPath, tree.FilePath), text.Lines.Count, null));
 			}
 			else {
 
 				var fullPath = ResolveFilePath(filePath, rootPath);
 
 				if(fullPath is null) {
-					results.Add(new { file = filePath, line_count = (int?) null, error = "file not found on disk" });
+					results.Add(new LineCountEntry(filePath, null, "file not found on disk"));
 					continue;
 				}
 
 				try {
 
 					var lineCount = await CountLinesAsync(fullPath);
-					results.Add(new { file = Path.GetRelativePath(rootPath, fullPath), line_count = (int?) lineCount, error = (string?) null });
+					results.Add(new LineCountEntry(Path.GetRelativePath(rootPath, fullPath), lineCount, null));
 				}
 				catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
-					results.Add(new { file = filePath, line_count = (int?) null, error = ex.Message });
+					results.Add(new LineCountEntry(filePath, null, ex.Message));
 				}
 			}
 		}
@@ -70,10 +70,10 @@ internal sealed class GetLineCountTool : RoslynMcpTool
 		var total      = results.Count;
 		var filesArr   = results.ToArray();
 
-		return scope.Outcome($"{total} file(s)", new {
-			files    = filesArr,
-			_caution = AdhocCaution(projectPath)
-		});
+		return scope.Outcome($"{total} file(s)", new LineCountResult(
+			Files:    filesArr,
+			_caution: AdhocCaution(projectPath)
+		));
 	}
 
     /// <summary>

--- a/src/RoslynMcp/Tools/Analysis/ListTypesTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ListTypesTool.cs
@@ -52,14 +52,14 @@ internal sealed class ListTypesTool : RoslynMcpTool
 
 		var result = PaginateAndStore(allResults, ref skip, take);
 
-		return scope.Outcome($"{result.Items.Length}/{result.Total} type(s)", new {
-			total_types = result.Total,
-			skip, take,
-			types      = result.Items,
-			page_token = result.PageToken,
-			has_more   = result.HasMore,
-			_caution   = AdhocCaution(projectPath)
-		});
+		return scope.Outcome($"{result.Items.Length}/{result.Total} type(s)", new ListTypesResult(
+			Total_types: result.Total,
+			Skip: skip, Take: take,
+			Types:      result.Items,
+			Page_token: result.PageToken,
+			Has_more:   result.HasMore,
+			_caution:   AdhocCaution(projectPath)
+		));
 	}
 	
 	private static void CollectTypes(INamespaceSymbol ns, List<INamedTypeSymbol> collector)

--- a/src/RoslynMcp/Tools/Analysis/ReadFileTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ReadFileTool.cs
@@ -76,14 +76,14 @@ internal sealed class ReadFileTool : RoslynMcpTool
 
         var relative = Path.GetRelativePath(rootPath, canonicalPath);
 
-        return scope.Outcome($"{result.Length}/{totalLines} line(s)", new {
-            file        = relative,
-            source      = isCs ? "roslyn" : "disk",
-            total_lines = totalLines,
-            start_line  = first,
-            end_line    = last,
-            lines       = result,
-            _caution    = AdhocCaution(projectPath)
-        });
+        return scope.Outcome($"{result.Length}/{totalLines} line(s)", new ReadFileResult(
+            File:        relative,
+            Source:      isCs ? "roslyn" : "disk",
+            Total_lines: totalLines,
+            Start_line:  first,
+            End_line:    last,
+            Lines:       result,
+            _caution:    AdhocCaution(projectPath)
+        ));
     }
 }

--- a/src/RoslynMcp/Tools/Analysis/TypeHierarchyTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/TypeHierarchyTool.cs
@@ -63,19 +63,19 @@ internal sealed class TypeHierarchyTool : RoslynMcpTool
 		;
 		var result   = PaginateAndStore(combined, ref skip, take);
 
-		return scope.Outcome($"{result.Items.Length} interface(s)/derived", new {
-			type_name           = type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-			type_kind           = type.TypeKind.ToString().ToLowerInvariant(),
-			base_types          = baseTypes,
-			total_interfaces    = allInterfaces.Length,
-			total_derived_types = allDerived.Length,
-			skip,
-			take,
-			interfaces_and_derived = result.Items,
-			page_token          = result.PageToken,
-			has_more            = result.HasMore,
-			_caution            = AdhocCaution(projectPath)
-		});
+		return scope.Outcome($"{result.Items.Length} interface(s)/derived", new TypeHierarchyResult(
+			Type_name:           type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+			Type_kind:           type.TypeKind.ToString().ToLowerInvariant(),
+			Base_types:          baseTypes,
+			Total_interfaces:    allInterfaces.Length,
+			Total_derived_types: allDerived.Length,
+			Skip: skip,
+			Take: take,
+			Interfaces_and_derived: result.Items,
+			Page_token:          result.PageToken,
+			Has_more:            result.HasMore,
+			_caution:            AdhocCaution(projectPath)
+		));
 	}
 	
 	private static INamedTypeSymbol? FindType(Compilation compilation, string typeName)

--- a/src/RoslynMcp/Tools/Analysis/TypeMembersTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/TypeMembersTool.cs
@@ -69,16 +69,16 @@ internal sealed class TypeMembersTool : RoslynMcpTool
 		
 		var result = PaginateAndStore(allMembers, ref skip, take);
 
-		return scope.Outcome($"{result.Items.Length}/{result.Total} member(s)", new {
-			type_name     = type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-			type_kind     = type.TypeKind.ToString().ToLowerInvariant(),
-			total_members = result.Total,
-			skip, take,
-			members    = result.Items,
-			page_token = result.PageToken,
-			has_more   = result.HasMore,
-			_caution   = AdhocCaution(projectPath)
-		});
+		return scope.Outcome($"{result.Items.Length}/{result.Total} member(s)", new TypeMembersResult(
+			Type_name:     type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+			Type_kind:     type.TypeKind.ToString().ToLowerInvariant(),
+			Total_members: result.Total,
+			Skip: skip, Take: take,
+			Members:    result.Items,
+			Page_token: result.PageToken,
+			Has_more:   result.HasMore,
+			_caution:   AdhocCaution(projectPath)
+		));
 	}
 	
 	private static INamedTypeSymbol? FindType(Compilation compilation, string typeName)

--- a/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
+++ b/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
@@ -92,13 +92,8 @@ internal sealed class InsertLinesTool : RoslynMcpTool
 
 		if(dryRun) {
 
-			return new {
-				applied       = false,
-				insertedAt    = insertIndex + 1,
-				lineCount     = newLines.Length,
-				insertedLines,
-				message       = $"Dry run: {newLines.Length} line(s) would be inserted at line {insertIndex + 1}."
-			};
+			return new InsertLinesResult(false, insertIndex + 1, newLines.Length, insertedLines,
+				$"Dry run: {newLines.Length} line(s) would be inserted at line {insertIndex + 1}.");
 		}
 
 		try {
@@ -111,11 +106,6 @@ internal sealed class InsertLinesTool : RoslynMcpTool
 
 		workspace.InvalidateFile(projectPath, fullPath);
 
-		return new {
-			applied       = true,
-			insertedAt    = insertIndex + 1,
-			lineCount     = newLines.Length,
-			insertedLines,
-		};
+		return new InsertLinesResult(true, insertIndex + 1, newLines.Length, insertedLines);
 	}
 }

--- a/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
@@ -78,23 +78,14 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 		];
 		
 		if(matches.Count == 0) {
-		
-			return new {
-				applied      = false,
-				matchCount   = 0,
-				changedLines = (int[]) [],
-				message      = "No matches found."
-			};
+
+			return new ReplaceInFileResult(false, 0, [], "No matches found.");
 		}
 		
 		if(dryRun) {
-		
-			return new {
-				applied      = false,
-				matchCount   = matches.Count,
-				changedLines,
-				message      = $"Dry run: {matches.Count} replacement(s) would be made."
-			};
+
+			return new ReplaceInFileResult(false, matches.Count, changedLines,
+				$"Dry run: {matches.Count} replacement(s) would be made.");
 		}
 		
 		var newContent = regex.Replace(originalContent, replacement);
@@ -110,11 +101,7 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 		// Invalidate the workspace so subsequent Roslyn tools see the updated source.
 		workspace.InvalidateFile(projectPath, fullPath);
 		
-		return new {
-			applied      = true,
-			matchCount   = matches.Count,
-			changedLines,
-		};
+		return new ReplaceInFileResult(true, matches.Count, changedLines);
 	}
 	
 	// Builds a sorted array of character offsets where each line starts.

--- a/src/RoslynMcp/Tools/Refactoring/ChangeSignatureTool.cs
+++ b/src/RoslynMcp/Tools/Refactoring/ChangeSignatureTool.cs
@@ -78,14 +78,14 @@ internal sealed class ChangeSignatureTool : RoslynMcpTool
 			$"{method.ContainingType?.ToDisplayString()}::{method.Name}({string.Join(",", method.Parameters.Select(p => p.Type.ToDisplayString()))})"
 		);
 
-		return scope.Outcome($"+{result.ParametersAdded.Length} param ({string.Join(", ", result.ParametersAdded)})", new {
-			diff                = result.Diff,
-			token,
-			message             = $"Review the diff, then call apply_signature_change with token '{token}' and approval 'y' or 'session'.",
-			parameters_added    = result.ParametersAdded,
-			deprecation_message = result.DeprecationMessage,
-			files_affected      = result.FilesAffected,
-			_caution            = AdhocCaution(projectPath)
-		});
+		return scope.Outcome($"+{result.ParametersAdded.Length} param ({string.Join(", ", result.ParametersAdded)})", new ChangeSignatureResult(
+			Diff:                result.Diff!,
+			Token:               token,
+			Message:             $"Review the diff, then call apply_signature_change with token '{token}' and approval 'y' or 'session'.",
+			Parameters_added:    result.ParametersAdded,
+			Deprecation_message: result.DeprecationMessage,
+			Files_affected:      result.FilesAffected,
+			_caution:            AdhocCaution(projectPath)
+		));
 	}
 }

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -355,14 +355,14 @@ internal abstract partial class RoslynMcpTool
 		scope.SetCacheTag(hit: true);
 		var page = Paginate(cached, ref skip, take);
 
-		return scope.Outcome($"{page.Length}/{cached.Length}", new {
-			items      = page,
-			total      = cached.Length,
-			skip,
-			take,
-			page_token = pageToken,
-			has_more   = skip + page.Length < cached.Length
-		});
+		return scope.Outcome($"{page.Length}/{cached.Length}", new CachedPageResult<T>(
+			Items:      page,
+			Total:      cached.Length,
+			Skip:       skip,
+			Take:       take,
+			Page_token: pageToken!,
+			Has_more:   skip + page.Length < cached.Length
+		));
 	}
 
 	/// <summary>

--- a/src/RoslynMcp/Tools/ToolResults.cs
+++ b/src/RoslynMcp/Tools/ToolResults.cs
@@ -1,0 +1,147 @@
+namespace RoslynMcp.Tools;
+
+// ── Shared ──────────────────────────────────────────────────────────────────
+
+/// <summary>Cached page response from <see cref="RoslynMcpTool.TryServeCachedPage{T}"/>.</summary>
+internal sealed record CachedPageResult<T>(
+	T[]    Items,
+	int    Total,
+	int    Skip,
+	int    Take,
+	string Page_token,
+	bool   Has_more
+);
+
+// ── Analysis tools ──────────────────────────────────────────────────────────
+
+internal sealed record FileOutlineResult(
+	string  File,
+	int     Total_types,
+	int     Skip,
+	int     Take,
+	object[] Types,
+	string  Page_token,
+	bool    Has_more,
+	string? _caution
+);
+
+internal sealed record FindReferencesResult(
+	int      Total_references,
+	string[] Symbols_searched,
+	int      Skip,
+	int      Take,
+	string[] References,
+	string   Page_token,
+	bool     Has_more,
+	string?  _caution
+);
+
+internal sealed record FindImplementationsResult(
+	string   Symbol_type,
+	string   Symbol_name,
+	int      Total_implementations,
+	int      Skip,
+	int      Take,
+	string[] Implementations,
+	string?  Page_token    = null,
+	bool     Has_more      = false,
+	string?  _caution      = null
+);
+
+internal sealed record FindOverridesResult(
+	string   Symbol_type,
+	string   Symbol_name,
+	int      Total_overrides,
+	int      Skip,
+	int      Take,
+	string[] Overrides,
+	string?  Page_token    = null,
+	bool     Has_more      = false,
+	string?  _caution      = null
+);
+
+internal sealed record ListTypesResult(
+	int      Total_types,
+	int      Skip,
+	int      Take,
+	string[] Types,
+	string   Page_token,
+	bool     Has_more,
+	string?  _caution
+);
+
+internal sealed record TypeHierarchyResult(
+	string   Type_name,
+	string   Type_kind,
+	string[] Base_types,
+	int      Total_interfaces,
+	int      Total_derived_types,
+	int      Skip,
+	int      Take,
+	string[] Interfaces_and_derived,
+	string   Page_token,
+	bool     Has_more,
+	string?  _caution
+);
+
+internal sealed record TypeMembersResult(
+	string    Type_name,
+	string    Type_kind,
+	int       Total_members,
+	int       Skip,
+	int       Take,
+	object?[] Members,
+	string    Page_token,
+	bool      Has_more,
+	string?   _caution
+);
+
+internal sealed record ReadFileResult(
+	string   File,
+	string   Source,
+	int      Total_lines,
+	int      Start_line,
+	int      End_line,
+	string[] Lines,
+	string?  _caution
+);
+
+internal sealed record LineCountResult(
+	object[] Files,
+	string?  _caution
+);
+
+internal sealed record LineCountEntry(
+	string  File,
+	int?    Line_count,
+	string? Error
+);
+
+// ── Editing tools ───────────────────────────────────────────────────────────
+
+internal sealed record ReplaceInFileResult(
+	bool  Applied,
+	int   MatchCount,
+	int[] ChangedLines,
+	string? Message = null
+);
+
+internal sealed record InsertLinesResult(
+	bool  Applied,
+	int   InsertedAt,
+	int   LineCount,
+	int[] InsertedLines,
+	string? Message = null
+);
+
+// ── Refactoring tools ───────────────────────────────────────────────────────
+
+internal sealed record ChangeSignatureResult(
+	string   Diff,
+	string   Token,
+	string   Message,
+	string[] Parameters_added,
+	string?  Deprecation_message,
+	int      Files_affected,
+	string?  _caution
+);


### PR DESCRIPTION
## Summary
Introduces `ToolResults.cs` with 14 typed records replacing anonymous `new { ... }` in success responses across 12 tool files:

- **CachedPageResult\<T\>** — shared cached page response
- **FileOutlineResult**, **FindReferencesResult**, **FindImplementationsResult**, **FindOverridesResult**, **ListTypesResult**, **TypeHierarchyResult**, **TypeMembersResult** — paged analysis tools
- **ReadFileResult**, **LineCountResult**, **LineCountEntry** — file content tools
- **ReplaceInFileResult**, **InsertLinesResult** — editing tools
- **ChangeSignatureResult** — refactoring tools

JSON field names preserved — no breaking change for agents.

Remaining unique per-tool shapes (GetMemberBody, SymbolInfo, BuildTool, etc.) will follow in a separate PR.

Part of #57

## Test plan
- [ ] Build succeeds
- [ ] Run test harness — all 41 tests pass
- [ ] Verify JSON output field names unchanged (spot-check a few tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)