### PR TITLE
fix: CRLF-agnostic pattern matching in replace_in_file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,20 @@ RoslynMcp/
 
 ---
 
+## Technical Notes
+
+### CRLF vs LF in MCP Tool Matching
+
+MCP transmits tool parameters as JSON, which uses `\n` (LF) for newlines. But files on Windows use `\r\n` (CRLF). Any tool that does literal string matching on file content — find-and-replace, anchor-based insertion, pattern search — will silently fail when a multi-line pattern arrives with LF but the file contains CRLF.
+
+This is not specific to RoslynMcp. **Any MCP server that matches tool input against file content is affected.** The pattern (content from disk with platform line endings, pattern from JSON with LF-only) is universal.
+
+RoslynMcp addresses this with `BuildLiteralRegex` in the tool base class, which replaces literal `\n` in escaped patterns with `\r?\n` so they match both line ending styles. Writing tools also offer a `normalizeLineEndings` parameter (default `true`) that adjusts replacement text to match the file's existing convention.
+
+If you're building MCP tools that edit files, consider handling this in your implementation.
+
+---
+
 ## Questions or Need Help?
 
 - **Open an issue** for questions or discussions

--- a/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
+++ b/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
@@ -80,7 +80,9 @@ internal sealed class InsertLinesTool : RoslynMcpTool
 			insertIndex = matchIndex;
 		}
 
-		var newLines    = text.Split('\n');
+		// Split on both \r\n and \n to avoid trailing \r in lines.
+		// WriteAllLines uses Environment.NewLine on output, matching platform convention.
+		var newLines    = text.Split(["\r\n", "\n"], StringSplitOptions.None);
 		var resultLines = new List<string>(lines.Length + newLines.Length);
 
 		resultLines.AddRange(lines[..insertIndex]);

--- a/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
@@ -28,7 +28,12 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 		[Description("The replacement text. Supports $1/$2 backreferences when useRegex=true.")                           ] string  replacement,
 		[Description("Treat pattern as a regular expression. Default: false.")                                            ] bool    useRegex  = false,
 		[Description("Preview replacements without writing the file. Returns what would change. Default: false.")         ] bool    dryRun    = false,
-		[Description("Case-sensitive matching. Default: true.")                                                           ] bool    caseSensitive = true
+		[Description("Case-sensitive matching. Default: true.")                                                           ] bool    caseSensitive = true,
+		[Description(
+			"Match line endings in the replacement text to the file's existing style (CRLF or LF). " +
+			"Default: true — prevents mixed line endings in the file. " +
+			"Set false only if your replacement text already has the correct line endings."
+		)] bool normalizeLineEndings = true
 	)
 	{
 		using var scope = BeginTool("roslyn_replace_in_file", filePath);
@@ -37,22 +42,26 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 
 		if(fullPath is null)
 			return scope.Failed("file not found", new ErrorResult($"File not found: {filePath}"));
-		
+
 		Regex regex;
-		
+
 		try {
-		
-			var options = RegexOptions.Compiled;
-			
-			if(!caseSensitive)
-				options |= RegexOptions.IgnoreCase;
-			
-			// Escape literal patterns so special characters match as-is.
-			var regexPattern = useRegex ? pattern : Regex.Escape(pattern);
-			regex            = new Regex(regexPattern, options);
+
+			if(useRegex) {
+
+				var options = RegexOptions.Compiled;
+
+				if(!caseSensitive)
+					options |= RegexOptions.IgnoreCase;
+
+				regex = new Regex(pattern, options);
+			}
+			else {
+				regex = BuildLiteralRegex(pattern, caseSensitive);
+			}
 		}
 		catch(ArgumentException ex) {
-		
+
 			return new ErrorResult($"Invalid regex pattern: {ex.Message}");
 		}
 		
@@ -88,7 +97,8 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 				$"Dry run: {matches.Count} replacement(s) would be made.");
 		}
 		
-		var newContent = regex.Replace(originalContent, replacement);
+		var effectiveReplacement = normalizeLineEndings ? NormalizeLineEndings(replacement, originalContent) : replacement;
+		var newContent = regex.Replace(originalContent, effectiveReplacement);
 		
 		try {
 			File.WriteAllText(fullPath, newContent);

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 
 namespace RoslynMcp.Tools;
@@ -434,6 +435,37 @@ internal abstract partial class RoslynMcpTool
 	///     to the platform directory separator. Agents commonly supply Unix-style paths; this
 	///     ensures suffix matching against Roslyn's <see cref="SyntaxTree.FilePath"/> works on Windows.
 	/// </summary>
+
+	/// <summary>
+	///     Builds a compiled regex for literal pattern matching, with CRLF-agnostic newline handling.
+	///     Literal newlines in the pattern match both <c>\n</c> and <c>\r\n</c> in the file content,
+	///     preventing silent match failures on Windows files.
+	/// </summary>
+	protected static Regex BuildLiteralRegex(string pattern, bool caseSensitive = true)
+	{
+		var escaped = Regex.Escape(pattern).Replace("\n", @"\r?\n");
+		var options = RegexOptions.Compiled;
+
+		if(!caseSensitive)
+			options |= RegexOptions.IgnoreCase;
+
+		return new Regex(escaped, options);
+	}
+
+	/// <summary>
+	///     Detects the dominant line ending in a string and normalizes the replacement text to match.
+	///     Returns the replacement unchanged if the file uses LF or the replacement already matches.
+	/// </summary>
+	protected static string NormalizeLineEndings(string replacement, string fileContent)
+	{
+		var hasCrlf = fileContent.Contains("\r\n");
+
+		if(hasCrlf && !replacement.Contains("\r\n"))
+			return replacement.Replace("\n", "\r\n");
+
+		return replacement;
+	}
+
 	protected static string NormalizePath(string filePath)
 		=> filePath.Replace('/', Path.DirectorySeparatorChar);
 


### PR DESCRIPTION
## Summary

Fixes silent match failures when `roslyn_replace_in_file` is used on Windows files (CRLF) with patterns containing LF-only newlines — the default when patterns arrive via MCP/JSON.

**Root cause:** MCP transmits strings over JSON, which uses `\n` for newlines. `File.ReadAllText` preserves the file's raw `\r\n`. Literal pattern matching (`Regex.Escape` + `Regex.Match`) requires exact byte-level equality, so `\n` in the pattern never matches `\r\n` in the file. Multi-line replacements silently return "No matches found."

**Fix:**
- `BuildLiteralRegex` helper in base class: replaces literal `\n` in escaped patterns with `\r?\n` so they match both LF and CRLF
- `normalizeLineEndings` parameter on `replace_in_file` (default: `true`): adjusts replacement text to match the file's existing line ending style, preventing mixed endings
- `InsertLinesTool`: fixes `text.Split('\n')` leaving trailing `\r` on CRLF input — now splits on both `\r\n` and `\n`

**Broader note:** This CRLF mismatch is likely a silent failure across the MCP ecosystem — any tool that does literal string matching on file content received via JSON is affected. The pattern (content from disk with platform line endings, pattern from JSON with LF) is universal.

## Test plan
- [ ] Build succeeds
- [ ] `roslyn_replace_in_file` with multi-line literal pattern matches on CRLF file
- [ ] `normalizeLineEndings=true` (default): replacement text gets CRLF on Windows files
- [ ] `normalizeLineEndings=false`: replacement text written as-is
- [ ] `roslyn_insert_lines` with CRLF text doesn't produce double `\r\r\n`
- [ ] Test harness passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)