### PR TITLE
refactor: result records for analysis tools (Phase 1c, PR 1/2)

### DIFF
--- a/src/RoslynMcp/Tools/Analysis/GetMemberBodyTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetMemberBodyTool.cs
@@ -27,19 +27,17 @@ internal sealed class GetMemberBodyTool : RoslynMcpTool
 		var symbol   = FindSymbol(compilation, symbolName, containingType);
 
 		if(symbol is null)
-			return scope.Failed("symbol not found", new {
-				error = $"Symbol '{symbolName}' not found. Use get_type_members or find_references to verify the name."
-			});
+			return scope.Failed("symbol not found", new ErrorResult($"Symbol '{symbolName}' not found.", Hint: "Use get_type_members or find_references to verify the name."));
 
 		var syntaxRefs = symbol.DeclaringSyntaxReferences;
 
 		if(syntaxRefs.Length == 0)
-			return new {
-				symbol_name = FormatSymbolName(symbol),
-				symbol_kind = symbol.Kind.ToString().ToLowerInvariant(),
-				location    = "metadata",
-				message     = "This symbol is defined in metadata (compiled assembly), not source code."
-			};
+			return new MetadataSymbolResult(
+				FormatSymbolName(symbol),
+				symbol.Kind.ToString().ToLowerInvariant(),
+				"metadata",
+				"This symbol is defined in metadata (compiled assembly), not source code."
+			);
 
 		var parts = new List<object>();
 
@@ -64,34 +62,34 @@ internal sealed class GetMemberBodyTool : RoslynMcpTool
 				: Path.GetRelativePath(rootPath, tree.FilePath)
 			;
 
-			parts.Add(new {
-				file       = filePath,
-				start_line = startLine + 1,
-				end_line   = endLine + 1,
-				body       = string.Join("\n", lines),
-				part_index = syntaxRefs.Length > 1 ? i + 1 : (int?) null
-			});
+			parts.Add(new MemberBodyPart(
+				filePath,
+				startLine + 1,
+				endLine + 1,
+				string.Join("\n", lines),
+				syntaxRefs.Length > 1 ? i + 1 : null
+			));
 		}
 
-		var totalLines = parts.Cast<dynamic>().Sum(p => (int) p.end_line - (int) p.start_line + 1);
+		var totalLines = parts.Cast<MemberBodyPart>().Sum(p => p.End_line - p.Start_line + 1);
 
 		return scope.Outcome($"{totalLines} line(s)", syntaxRefs.Length == 1
-			? new {
-				symbol_name = FormatSymbolName(symbol),
-				symbol_kind = symbol.Kind.ToString().ToLowerInvariant(),
-				file        = ((dynamic) parts[0]).file,
-				start_line  = ((dynamic) parts[0]).start_line,
-				end_line    = ((dynamic) parts[0]).end_line,
-				body        = ((dynamic) parts[0]).body,
-				_caution    = AdhocCaution(projectPath)
-			}
-			: (object) new {
-				symbol_name = FormatSymbolName(symbol),
-				symbol_kind = symbol.Kind.ToString().ToLowerInvariant(),
+			? new MemberBodySingleResult(
+				FormatSymbolName(symbol),
+				symbol.Kind.ToString().ToLowerInvariant(),
+				((MemberBodyPart) parts[0]).File,
+				((MemberBodyPart) parts[0]).Start_line,
+				((MemberBodyPart) parts[0]).End_line,
+				((MemberBodyPart) parts[0]).Body,
+				AdhocCaution(projectPath)
+			)
+			: (object) new MemberBodyPartialResult(
+				FormatSymbolName(symbol),
+				symbol.Kind.ToString().ToLowerInvariant(),
 				parts,
-				note        = $"Partial declaration — {syntaxRefs.Length} parts across {parts.Select(p => ((dynamic) p).file).Distinct().Count()} file(s).",
-				_caution    = AdhocCaution(projectPath)
-			}
+				$"Partial declaration — {syntaxRefs.Length} parts across {parts.Cast<MemberBodyPart>().Select(p => p.File).Distinct().Count()} file(s).",
+				AdhocCaution(projectPath)
+			)
 		);
 	}
 

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
@@ -32,12 +32,12 @@ internal sealed class GetSymbolDefinitionTool : RoslynMcpTool
 		var location = symbol.Locations.FirstOrDefault(loc => loc.IsInSource);
 		
 		if(location is null)
-			return new {
-				symbol_name = FormatSymbolName(symbol),
-				symbol_kind = symbol.Kind.ToString().ToLowerInvariant(),
-				location    = "metadata",
-				message     = "This symbol is defined in metadata (compiled assembly), not source code."
-			};
+			return new MetadataSymbolResult(
+				FormatSymbolName(symbol),
+				symbol.Kind.ToString().ToLowerInvariant(),
+				"metadata",
+				"This symbol is defined in metadata (compiled assembly), not source code."
+			);
 		
 		var span      = location.GetLineSpan();
 		var filePath  = span.Path;
@@ -46,16 +46,16 @@ internal sealed class GetSymbolDefinitionTool : RoslynMcpTool
 		var docXml    = symbol.GetDocumentationCommentXml();
 		var docSummary = ExtractDocSummary(docXml);
 		
-		return new {
-			symbol_name = FormatSymbolName(symbol),
-			symbol_kind = symbol.Kind.ToString().ToLowerInvariant(),
-			file        = relative,
-			line        = span.StartLinePosition.Line + 1,
-			column      = span.StartLinePosition.Character + 1,
-			signature   = signature,
-			doc_summary = docSummary,
-			_caution    = AdhocCaution(projectPath)
-		};
+		return new SymbolDefinitionResult(
+			FormatSymbolName(symbol),
+			symbol.Kind.ToString().ToLowerInvariant(),
+			relative,
+			span.StartLinePosition.Line + 1,
+			span.StartLinePosition.Character + 1,
+			signature,
+			docSummary,
+			AdhocCaution(projectPath)
+		);
 	}
 	
 	

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
@@ -33,25 +33,25 @@ internal sealed class GetSymbolDocumentationTool : RoslynMcpTool
 		var xml = symbol.GetDocumentationCommentXml();
 		
 		if(string.IsNullOrWhiteSpace(xml))
-			return new {
-				symbol_name = FormatSymbolName(symbol),
-				symbol_kind = symbol.Kind.ToString().ToLowerInvariant(),
-				documentation = (string?) null,
-				message = "No documentation comments found for this symbol."
-			};
+			return new SymbolDocumentationEmptyResult(
+				FormatSymbolName(symbol),
+				symbol.Kind.ToString().ToLowerInvariant(),
+				null,
+				"No documentation comments found for this symbol."
+			);
 		
 		var parsed = ParseDocumentation(xml);
 		
-		return new {
-			symbol_name   = FormatSymbolName(symbol),
-			symbol_kind   = symbol.Kind.ToString().ToLowerInvariant(),
-			summary       = parsed.Summary,
-			parameters    = parsed.Parameters,
-			returns       = parsed.Returns,
-			remarks       = parsed.Remarks,
-			example       = parsed.Example,
-			_caution      = AdhocCaution(projectPath)
-		};
+		return new SymbolDocumentationResult(
+			FormatSymbolName(symbol),
+			symbol.Kind.ToString().ToLowerInvariant(),
+			parsed.Summary,
+			parsed.Parameters,
+			parsed.Returns,
+			parsed.Remarks,
+			parsed.Example,
+			AdhocCaution(projectPath)
+		);
 	}
 	
 	

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolsInScopeTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolsInScopeTool.cs
@@ -93,19 +93,19 @@ internal sealed class GetSymbolsInScopeTool : RoslynMcpTool
 		SymbolInfo[] typesArr      = [.. types];
 		SymbolInfo[] otherArr      = [.. other];
 
-		return new {
-			file       = Path.GetRelativePath(rootPath, tree.FilePath),
+		return new SymbolsInScopeResult(
+			Path.GetRelativePath(rootPath, tree.FilePath),
 			line,
 			column,
-			locals     = localsArr,
-			parameters = parametersArr,
-			fields     = fieldsArr,
-			properties = propertiesArr,
-			methods    = methodsArr,
-			types      = typesArr,
-			other      = otherArr,
-			_caution   = AdhocCaution(projectPath)
-		};
+			localsArr,
+			parametersArr,
+			fieldsArr,
+			propertiesArr,
+			methodsArr,
+			typesArr,
+			otherArr,
+			AdhocCaution(projectPath)
+		);
 	}
 	
 	private static int GetPosition(SourceText text, int line, int column)
@@ -137,5 +137,5 @@ internal sealed class GetSymbolsInScopeTool : RoslynMcpTool
 		return new SymbolInfo(kind, name, type, containingType);
 	}
 	
-	private sealed record SymbolInfo(string Kind, string Name, string? Type, string? ContainingType);
+	internal sealed record SymbolInfo(string Kind, string Name, string? Type, string? ContainingType);
 }

--- a/src/RoslynMcp/Tools/Analysis/GetUsingsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetUsingsTool.cs
@@ -49,12 +49,12 @@ internal sealed class GetUsingsTool : RoslynMcpTool
 			? ExtractGlobalUsings(compilation)
 			: [];
 		
-		return new {
-			file          = Path.GetRelativePath(rootPath, tree.FilePath),
-			usings        = usings,
-			global_usings = globalUsings,
-			_caution      = AdhocCaution(projectPath)
-		};
+		return new GetUsingsResult(
+			Path.GetRelativePath(rootPath, tree.FilePath),
+			usings,
+			globalUsings,
+			AdhocCaution(projectPath)
+		);
 	}
 	
 	private static string[] ExtractGlobalUsings(Compilation compilation)
@@ -79,5 +79,5 @@ internal sealed class GetUsingsTool : RoslynMcpTool
 		return [.. globalUsings.Order()];
 	}
 	
-	private sealed record UsingDirective(string? Namespace, string? Alias);
+	internal sealed record UsingDirective(string? Namespace, string? Alias);
 }

--- a/src/RoslynMcp/Tools/Analysis/ProjectInfoTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ProjectInfoTool.cs
@@ -49,21 +49,21 @@ internal sealed class ProjectInfoTool : RoslynMcpTool
 				.Order()
 		];
 		
-		return new {
-			name            = project.Name,
-			assembly_name   = project.AssemblyName,
-			file_path       = project.FilePath is not null
+		return new ProjectInfoResult(
+			project.Name,
+			project.AssemblyName,
+			project.FilePath is not null
 				? Path.GetRelativePath(rootPath, project.FilePath)
 				: null,
-			target_framework    = tfm,
-			language_version    = langVersion,
-			output_kind         = outputKind,
-			nullable            = nullable,
-			is_msbuild_workspace = isMSBuild,
-			package_references  = packages,
-			additional_files    = extraFiles,
-			_caution            = AdhocCaution(projectPath)
-		};
+			tfm,
+			langVersion,
+			outputKind,
+			nullable,
+			isMSBuild,
+			packages,
+			extraFiles,
+			AdhocCaution(projectPath)
+		);
 	}
 	
 	private static string? InferTfm(Project project)

--- a/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
@@ -49,29 +49,24 @@ internal sealed class SymbolInfoTool : RoslynMcpTool
 			var typeInfo = model.GetTypeInfo(node);
 
 			if(typeInfo.Type is not null)
-				return new {
-					kind = "type",
-					name = typeInfo.Type.ToDisplayString(),
-					containing_type = (string?) null,
-					type_or_return  = (string?) null
-				};
+				return new SymbolInfoResult("type", typeInfo.Type.ToDisplayString(), null, null);
 
 			return new ErrorResult("No symbol resolved at that position.");
 		}
 
-		return new {
-			kind            = symbol.Kind.ToString().ToLowerInvariant(),
-			name            = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-			containing_type = symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-			type_or_return  = symbol switch {
+		return new SymbolInfoResult(
+			symbol.Kind.ToString().ToLowerInvariant(),
+			symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+			symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+			symbol switch {
 				IMethodSymbol   m => m.ReturnType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
 				IPropertySymbol p => p.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
 				IFieldSymbol    f => f.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
 				ILocalSymbol    l => l.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-				_                 => (string?) null
+				_                 => null
 			},
-			_caution = AdhocCaution(projectPath)
-		};
+			AdhocCaution(projectPath)
+		);
 	}
 
 	private static int GetPosition(SourceText text, int line, int column)

--- a/src/RoslynMcp/Tools/ToolResults.cs
+++ b/src/RoslynMcp/Tools/ToolResults.cs
@@ -117,6 +117,111 @@ internal sealed record LineCountEntry(
 	string? Error
 );
 
+internal sealed record MemberBodySingleResult(
+	string  Symbol_name,
+	string  Symbol_kind,
+	string  File,
+	int     Start_line,
+	int     End_line,
+	string  Body,
+	string? _caution
+);
+
+internal sealed record MemberBodyPartialResult(
+	string        Symbol_name,
+	string        Symbol_kind,
+	List<object>  Parts,
+	string        Note,
+	string?       _caution
+);
+
+internal sealed record MemberBodyPart(
+	string  File,
+	int     Start_line,
+	int     End_line,
+	string  Body,
+	int?    Part_index
+);
+
+internal sealed record MetadataSymbolResult(
+	string Symbol_name,
+	string Symbol_kind,
+	string Location,
+	string Message
+);
+
+internal sealed record SymbolDefinitionResult(
+	string  Symbol_name,
+	string  Symbol_kind,
+	string  File,
+	int     Line,
+	int     Column,
+	string  Signature,
+	string? Doc_summary,
+	string? _caution
+);
+
+internal sealed record SymbolDocumentationResult(
+	string  Symbol_name,
+	string  Symbol_kind,
+	string? Summary,
+	object? Parameters,
+	string? Returns,
+	string? Remarks,
+	string? Example,
+	string? _caution
+);
+
+internal sealed record SymbolDocumentationEmptyResult(
+	string  Symbol_name,
+	string  Symbol_kind,
+	string? Documentation,
+	string  Message
+);
+
+internal sealed record SymbolInfoResult(
+	string  Kind,
+	string  Name,
+	string? Containing_type,
+	string? Type_or_return,
+	string? _caution = null
+);
+
+internal sealed record SymbolsInScopeResult(
+	string                              File,
+	int                                 Line,
+	int                                 Column,
+	GetSymbolsInScopeTool.SymbolInfo[]  Locals,
+	GetSymbolsInScopeTool.SymbolInfo[]  Parameters,
+	GetSymbolsInScopeTool.SymbolInfo[]  Fields,
+	GetSymbolsInScopeTool.SymbolInfo[]  Properties,
+	GetSymbolsInScopeTool.SymbolInfo[]  Methods,
+	GetSymbolsInScopeTool.SymbolInfo[]  Types,
+	GetSymbolsInScopeTool.SymbolInfo[]  Other,
+	string?                             _caution
+);
+
+internal sealed record GetUsingsResult(
+	string              File,
+	GetUsingsTool.UsingDirective[] Usings,
+	string[]            Global_usings,
+	string?             _caution
+);
+
+internal sealed record ProjectInfoResult(
+	string   Name,
+	string   Assembly_name,
+	string?  File_path,
+	string?  Target_framework,
+	string   Language_version,
+	string   Output_kind,
+	string   Nullable,
+	bool     Is_msbuild_workspace,
+	object[] Package_references,
+	string[] Additional_files,
+	string?  _caution
+);
+
 // ── Editing tools ───────────────────────────────────────────────────────────
 
 internal sealed record ReplaceInFileResult(


### PR DESCRIPTION
## Summary
Replaces anonymous types in 7 analysis tool files with 11 new typed records:

- **GetMemberBodyTool** — `MemberBodySingleResult`, `MemberBodyPartialResult`, `MemberBodyPart`, `MetadataSymbolResult` (also removes `dynamic` casts)
- **GetSymbolDefinitionTool** — `MetadataSymbolResult` (shared), `SymbolDefinitionResult`
- **GetSymbolDocumentationTool** — `SymbolDocumentationResult`, `SymbolDocumentationEmptyResult`
- **SymbolInfoTool** — `SymbolInfoResult`
- **GetSymbolsInScopeTool** — `SymbolsInScopeResult`
- **GetUsingsTool** — `GetUsingsResult`
- **ProjectInfoTool** — `ProjectInfoResult`

JSON field names preserved — no breaking change. Remaining tools (GetTrivia, Build, ReplaceInCode, Search, Debug, Respawn + base class) follow in PR 2/2.

Part of #57

## Test plan
- [ ] Build succeeds
- [ ] Test harness passes
- [ ] Spot-check JSON output field names unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)