### PR TITLE
docs: subagent delegation guidance for agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,30 @@ When discovering files/content:
 
 This is very important! It helps to test the tools, dogfood the API, and ensures your agent gets accurate semantic understanding of the codebase. Avoid workarounds like grepping files or spawning builds unless absolutely necessary. I'm serious: get this through your thick pirate skull: DOGFOOD the living daylights out of all this!
 
+### Subagents Don't Inherit Instructions
+
+If you spawn subagents (Claude Code Agent tool, background workers, task delegation), they **do not see this file**. They will default to Read/Grep/Edit unless explicitly told otherwise. When delegating C# work, include this in the subagent prompt:
+
+```
+Use roslyn_* MCP tools for ALL C# file operations — do NOT use built-in
+Read/Grep/Edit/Glob/Bash tools for C# code:
+
+Reading:     roslyn_get_member_body (single method/property) or roslyn_read_file (whole file)
+Structure:   roslyn_get_file_outline (types + signatures, no bodies)
+Search:      roslyn_search_files or roslyn_semantic_search (not Grep)
+Files:       roslyn_list_files (not Glob)
+References:  roslyn_find_references (semantic, cross-project)
+Impls:       roslyn_find_implementations (interfaces, overrides)
+Definition:  roslyn_get_symbol_definition (file + line + signature)
+Types:       roslyn_get_type_members, roslyn_get_type_hierarchy
+Editing:     roslyn_replace_in_code (C#) or roslyn_replace_in_file (any file)
+Inserting:   roslyn_insert_lines (by line number or anchor pattern)
+Renaming:    roslyn_preview_rename + roslyn_apply_rename
+Signatures:  roslyn_change_signature + roslyn_apply_signature_change
+Building:    roslyn_build_project (NEVER run dotnet build in terminal)
+Diagnostics: roslyn_get_diagnostics for fast error checks
+```
+
 ### Exception: Style Enforcement
 
 Code style enforcement (indented blank lines, spacing, etc.) is handled by `.\scripts\Test-CodeStyle.ps1` rather than a Roslyn tool. **Why?**

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ When working with C# code, prefer roslyn_* MCP tools:
 - `roslyn_get_diagnostics` with `severity: "errors"` for fast error checks
 ```
 
-For complete instructions covering every tool, see [docs/AGENT-INSTRUCTIONS.md](docs/AGENT-INSTRUCTIONS.md) — includes both a full version and a compact version.
+For complete instructions covering every tool, see [docs/AGENT-INSTRUCTIONS.md](docs/AGENT-INSTRUCTIONS.md) — includes a full version, a compact version, and guidance for subagent delegation (subagents don't inherit your instructions).
 
 ---
 

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -124,3 +124,21 @@ are more accurate than grep/Read/Edit.
 - Build: `roslyn_build_project` > NEVER `dotnet build` in terminal
 - Diagnostics: `roslyn_get_diagnostics` for fast error checks
 ```
+
+---
+
+## Subagents and Delegated Tasks
+
+If your AI tool supports spawning subagents (e.g., Claude Code's Agent tool, background workers, or task delegation), those subagents **do not inherit your agent instructions**. They will default to built-in tools unless explicitly told otherwise.
+
+When delegating C# work to a subagent, include this in the prompt:
+
+```
+Use roslyn_* MCP tools for all C# file operations:
+- roslyn_read_file / roslyn_get_member_body instead of Read
+- roslyn_search_files instead of Grep
+- roslyn_replace_in_code / roslyn_replace_in_file instead of Edit
+- roslyn_build_project instead of dotnet build
+```
+
+This is easy to forget — the main agent follows the instructions perfectly, then delegates to a subagent that reverts to grep and file reads. If you notice a subagent using built-in tools on C# files, that's the cause.

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -134,11 +134,23 @@ If your AI tool supports spawning subagents (e.g., Claude Code's Agent tool, bac
 When delegating C# work to a subagent, include this in the prompt:
 
 ```
-Use roslyn_* MCP tools for all C# file operations:
-- roslyn_read_file / roslyn_get_member_body instead of Read
-- roslyn_search_files instead of Grep
-- roslyn_replace_in_code / roslyn_replace_in_file instead of Edit
-- roslyn_build_project instead of dotnet build
+Use roslyn_* MCP tools for ALL C# file operations — do NOT use built-in
+Read/Grep/Edit/Glob/Bash tools for C# code:
+
+Reading:     roslyn_get_member_body (single method/property) or roslyn_read_file (whole file)
+Structure:   roslyn_get_file_outline (types + signatures, no bodies)
+Search:      roslyn_search_files or roslyn_semantic_search (not Grep)
+Files:       roslyn_list_files (not Glob)
+References:  roslyn_find_references (semantic, cross-project)
+Impls:       roslyn_find_implementations (interfaces, overrides)
+Definition:  roslyn_get_symbol_definition (file + line + signature)
+Types:       roslyn_get_type_members, roslyn_get_type_hierarchy
+Editing:     roslyn_replace_in_code (C#) or roslyn_replace_in_file (any file)
+Inserting:   roslyn_insert_lines (by line number or anchor pattern)
+Renaming:    roslyn_preview_rename + roslyn_apply_rename
+Signatures:  roslyn_change_signature + roslyn_apply_signature_change
+Building:    roslyn_build_project (NEVER run dotnet build in terminal)
+Diagnostics: roslyn_get_diagnostics for fast error checks
 ```
 
 This is easy to forget — the main agent follows the instructions perfectly, then delegates to a subagent that reverts to grep and file reads. If you notice a subagent using built-in tools on C# files, that's the cause.


### PR DESCRIPTION
## Summary
Adds a "Subagents and Delegated Tasks" section to `docs/AGENT-INSTRUCTIONS.md` explaining that subagents don't inherit the parent's instructions and will default to built-in tools. Includes copy-paste prompt text for delegating C# work. Also updates the README link to mention subagent guidance.

Born from experience: we kept spawning agents that used Read/Grep/Edit instead of roslyn_* tools because they didn't know better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)