### PR TITLE
feat: token estimation in tool log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ RoslynMcp works. We use it daily for C# development with AI agents. But it is al
 
 **Tool description refinements.** The one-line descriptions that agents see determine whether they pick the right tool. If you notice an agent making poor tool choices, a PR that improves a description is a genuinely useful contribution.
 
+**Multi-agent resource usage.** Each subagent spawns its own MCP server process with its own Roslyn workspace (~100MB+ RAM, ~10s load time). Parallel subagents multiply this cost. We're exploring shared workspaces, pre-warmed pools, and subagent specialization patterns — see [#85](https://github.com/MadQ/RoslynMcp/issues/85) for the design discussion.
+
 If any of this sounds interesting, [open an issue](https://github.com/MadQ/RoslynMcp/issues) or submit a PR.
 
 ---

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -154,3 +154,5 @@ Diagnostics: roslyn_get_diagnostics for fast error checks
 ```
 
 This is easy to forget — the main agent follows the instructions perfectly, then delegates to a subagent that reverts to grep and file reads. If you notice a subagent using built-in tools on C# files, that's the cause.
+
+**Resource note:** Each subagent spawns its own MCP server process with its own Roslyn workspace (~100MB+ RAM, ~10s load time). Limit parallel subagents on large solutions to avoid resource exhaustion. See [#85](https://github.com/MadQ/RoslynMcp/issues/85) for ongoing work on shared workspaces and subagent specialization.

--- a/src/RoslynMcp/FileLogger.cs
+++ b/src/RoslynMcp/FileLogger.cs
@@ -20,7 +20,8 @@ internal sealed class FileLogger : IDisposable
 	
 	readonly string? logPath;
 	readonly object  writeLock = new();
-	
+	long             sessionTokens;
+
 	public bool IsEnabled => logPath is not null;
 	
 	public FileLogger()
@@ -61,7 +62,7 @@ internal sealed class FileLogger : IDisposable
 	
 	/// <summary>Logs a tool invocation with outcome, elapsed time, and workspace mode indicator.</summary>
 	/// <param name="isMSBuild">True for MSBuildWorkspace (◆), false for AdhocWorkspace (◇), null when unknown.</param>
-	public void LogTool(string toolName, long elapsedMs, bool success, string? subject = null, string? detail = null, bool isMSBuild = true, string? cacheTag = null)
+	public void LogTool(string toolName, long elapsedMs, bool success, string? subject = null, string? detail = null, bool isMSBuild = true, string? cacheTag = null, int estimatedTokens = 0)
 	{
 		var outcome   = success ? "OK   " : "ERROR";
 		var ws        = isMSBuild ? "MSB" : "ADH";
@@ -71,6 +72,9 @@ internal sealed class FileLogger : IDisposable
 		;
 		var cache = cacheTag switch { "HIT" => " [HIT]", "MISS" => " [MISS]", _ => "" };
 
+		if(estimatedTokens > 0)
+			Interlocked.Add(ref sessionTokens, estimatedTokens);
+
 		var sb = new System.Text.StringBuilder();
 		sb.Append($"{ws} {outcome} {elapsedMs,5}ms {shortName,-25}");
 
@@ -79,6 +83,9 @@ internal sealed class FileLogger : IDisposable
 
 		if(detail is not null)
 			sb.Append($" — {detail}");
+
+		if(estimatedTokens > 0)
+			sb.Append($" ~{estimatedTokens}tok ({Interlocked.Read(ref sessionTokens)}tot)");
 
 		sb.Append(cache);
 

--- a/src/RoslynMcp/Tools/RoslynMcpTool.ToolScope.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.ToolScope.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Text.Json;
 
 namespace RoslynMcp.Tools;
 
@@ -20,6 +21,7 @@ internal abstract partial class RoslynMcpTool
 		string? detail;
 		bool    isMSBuild = true;  // Default MSBuild (95% case); SetWorkspaceMode overrides.
 		string? cacheTag;          // null = not paginated, "HIT" or "MISS"
+		int     estimatedTokens;
 
 		internal ToolScope(string name, string? subject, FileLogger log, Action onDispose)
 		{
@@ -39,7 +41,12 @@ internal abstract partial class RoslynMcpTool
 		public void Outcome(string detail) => this.detail = detail;
 
 		/// <summary>Records a success detail and returns <paramref name="returnValue"/> for fluent use in return statements.</summary>
-		public T Outcome<T>(string detail, T returnValue) { this.detail = detail; return returnValue; }
+		public T Outcome<T>(string detail, T returnValue)
+		{
+			this.detail     = detail;
+			estimatedTokens = EstimateTokens(returnValue);
+			return returnValue;
+		}
 
 		/// <summary>Marks the invocation as failed with a reason appended to the log line on dispose.</summary>
 		public void Failed(string reason) { failed = true; detail = reason; }
@@ -52,8 +59,20 @@ internal abstract partial class RoslynMcpTool
 
 		public void Dispose()
 		{
-			log.LogTool(name, sw.ElapsedMilliseconds, !failed, subject, detail, isMSBuild, cacheTag);
+			log.LogTool(name, sw.ElapsedMilliseconds, !failed, subject, detail, isMSBuild, cacheTag, estimatedTokens);
 			onDispose();
+		}
+
+		/// <summary>Rough token estimate: serialize to JSON, divide chars by 4.</summary>
+		static int EstimateTokens<T>(T value)
+		{
+			try {
+				var json = JsonSerializer.Serialize(value);
+				return json.Length / 4;
+			}
+			catch {
+				return 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Adds per-tool and session-cumulative token estimation to the log output. Each tool call now shows `~Ntok (Ntot)` — estimated response tokens and running session total.

**Example log output:**
```
[22:07:09.625] [TOOL  ] MSB OK  11493ms get_member_body  LogTool — 29 line(s) ~342tok (342tot)
[22:07:09.658] [TOOL  ] MSB OK  12844ms get_file_outline FileLogger.cs — 1/1 type(s) ~349tok (691tot) [MISS]
[22:07:12.007] [TOOL  ] MSB OK  13310ms find_references  estimatedTokens — 2/2 ref(s) ~76tok (767tot)
```

**Implementation:**
- `ToolScope.Outcome<T>` serializes the return value to JSON and divides by 4 (standard rough chars-per-token for code)
- `FileLogger` tracks session total via `Interlocked.Add` (thread-safe)
- Only logged when estimate > 0 (error paths without Outcome don't show)

## Test plan
- [ ] Build succeeds
- [ ] Token estimates appear in log for tool calls
- [ ] Session total accumulates correctly
- [ ] Error paths don't show spurious `~0tok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)