### PR TITLE
chore: full doc-code sweep — sync tool counts, fix stale examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ When in doubt: **ask, don't assume.** A thirty-second question beats reverting s
 | **Runtime** | .NET 8 / .NET 10 (net11.0 auto-added when .NET 11 SDK is detected) |
 | **Language** | C# 14 (`<LangVersion>preview</LangVersion>`) |
 | **Version** | 0.7.0-alpha (pre-1.0) |
-| **Tool Count** | 28 MCP tools (25 stable + 2 refactoring + 1 experimental) |
+| **Tool Count** | 33 MCP tools (27 stable + 2 refactoring + 1 experimental + 3 infrastructure) |
 | **Dependencies** | `Microsoft.CodeAnalysis.*` (Roslyn) — MSBuildWorkspace (if .csproj found) → AdhocWorkspace (fallback) |
 | **ImplicitUsings** | `enable` — don't add redundant `using` directives |
 | **Resources** | [C# MCP SDK](https://csharp.sdk.modelcontextprotocol.io/) • [MCP Spec](https://modelcontextprotocol.io/) |
@@ -64,6 +64,7 @@ Use `roslyn_build_project` to build — not `dotnet build` in a terminal.
 | `ListFilesTool` | `roslyn_list_files` — enumerate files matching glob pattern (fast file listing, no content) |
 | `ReplaceInFileTool` | `roslyn_replace_in_file` — text-level find/replace with regex support (any file type) |
 | `ReplaceInCodeTool` | `roslyn_replace_in_code` — semantic C# node replacement using Roslyn (validates syntax, preserves formatting) |
+| `InsertLinesTool` | `roslyn_insert_lines` — insert lines at a position or anchor pattern |
 | `RespawnTool` | `roslyn_respawn` (DEBUG only) — terminates server process for hot-reload during development — not very reliable |
 | `TypeMembersTool` | `roslyn_get_type_members` — enumerate members with full signatures + doc summaries |
 | `DiagnosticsTool` | `roslyn_get_diagnostics` — compiler errors and warnings for project or single file |
@@ -71,6 +72,8 @@ Use `roslyn_build_project` to build — not `dotnet build` in a terminal.
 | `SymbolInfoTool` | `roslyn_get_symbol_info` — resolve what a name at a location actually is |
 | `PreviewRenameTool` | `roslyn_preview_rename` — compute rename edits, return unified diff + token |
 | `ApplyRenameTool` | `roslyn_apply_rename` — approve/reject a pending rename by token |
+| `ChangeSignatureTool` | `roslyn_change_signature` — add parameters with non-breaking forwarding overload |
+| `ApplySignatureChangeTool` | `roslyn_apply_signature_change` — apply or reject a previewed signature change |
 | `ProjectInfoTool` | `roslyn_get_project_info` — project metadata (TFM, language version, packages, etc.) |
 | `BuildTool` | `roslyn_build_project` — check Roslyn diagnostics first (fast), skip build if errors; run `dotnet build` if clean or `forceBuild=true` |
 | `CleanSolutionTool` | `roslyn_clean_solution` — remove all build artifacts (bin/obj directories) |
@@ -83,6 +86,8 @@ Use `roslyn_build_project` to build — not `dotnet build` in a terminal.
 | `GetSymbolDocumentationTool` | `roslyn_get_symbol_documentation` — XML doc comments for symbols |
 | `GetSymbolDefinitionTool` | `roslyn_get_symbol_definition` — find declaration location with signature |
 | `GetSymbolsInScopeTool` | `roslyn_get_symbols_in_scope` — enumerate accessible symbols at a location |
+| `ReadFileTool` | `roslyn_read_file` — file contents with line numbers (C# from in-memory workspace) |
+| `GetLineCountTool` | `roslyn_get_line_count` — line count for one or more files |
 | `GetMemberBodyTool` | `roslyn_get_member_body` — return full source of a single method/property/field/type by name; handles partial types |
 | `GetTriviaTool` | `roslyn_get_trivia` (**EXPERIMENTAL**) — extract whitespace, comments, and formatting trivia; filter by syntax kind, trivia kind, or line range; useful for understanding indentation context |
 | `ApprovalStore` | Session-scoped approval state (`y`, `n`, `session` model) |
@@ -93,9 +98,9 @@ Use `roslyn_build_project` to build — not `dotnet build` in a terminal.
 **Key files:** `Program.cs` (MCP protocol), `WorkspaceManager.cs` + `.Resolution.cs` + `.Instance.cs` (workspace caching, path resolution, workspace lifecycle), `WorkspaceResolver.cs` (tool facade), `RoslynMcpTool.cs` + `RoslynMcpTool.ToolScope.cs` + `RoslynMcpTool.Discovery.cs` (base class), `FileLogger.cs` (file logging).
 
 **Tool subfolders** (all share the `RoslynMcp.Tools` namespace — subfolders are organisational only):
-- `Tools/Analysis/` — 13 read-only Roslyn semantic queries (diagnostics, symbols, types, usings, outline, …)
+- `Tools/Analysis/` — 17 read-only Roslyn semantic queries (diagnostics, symbols, types, usings, outline, …)
 - `Tools/Search/` — 3 file/content search tools (list files, text search, semantic search)
-- `Tools/Editing/` — 2 file mutation tools (`roslyn_replace_in_file`, `roslyn_replace_in_code`)
+- `Tools/Editing/` — 3 file mutation tools (`roslyn_replace_in_file`, `roslyn_replace_in_code`, `roslyn_insert_lines`)
 - `Tools/Rename/` — 2-step rename workflow (`roslyn_preview_rename` → `roslyn_apply_rename`)
 - `Tools/Build/` — 3 MSBuild/dotnet CLI tools (build, clean, restore)
 - `Tools/` root — `RoslynMcpTool.cs`, `RoslynMcpTool.ToolScope.cs`, `RespawnTool.cs` (debug-only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FindSyntaxTree` → `RoslynMcpTool` base class (normalizes + suffix matches, used by 8+ tools)
 
 ### Docs
-- AGENTS.md updated: constructor pattern, rename API, tool tips section, tool count 26
+- AGENTS.md updated: constructor pattern, rename API, tool tips section, tool count 33
 - README: highlights solution loading, pagination, get_member_body, smart build 17ms, active roadmap
 - `docs/plans/pagination-cache.md` — design doc for token-based pagination
 - `docs/plans/oop-dry-opportunities.md` — 7 refactoring opportunities in 3 phases

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ dotnet build src/RoslynMcp/RoslynMcp.csproj -f net10.0
 ### Running Tests
 
 ```bash
-# Run the comprehensive test suite (36 tests covering all 28 tools)
+# Run the comprehensive test suite (41 tests covering all tools)
 dotnet run --project src/TestHarness/TestHarness.csproj
 ```
 
@@ -134,7 +134,8 @@ Publish a Release build and configure your MCP client to use it:
    [McpServerToolType]
    internal sealed class MyNewTool : RoslynMcpTool
    {
-       public MyNewTool(WorkspaceResolver workspace) : base(workspace) { }
+       public MyNewTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache)
+           : base(workspace, logger, paginationCache) { }
 
        [McpServerTool, Description("...")]
        public object MyToolMethod(
@@ -145,6 +146,7 @@ Publish a Release build and configure your MCP client to use it:
                return error;
 
            // Use Roslyn APIs here
+           // Typed result records are preferred over anonymous objects
            return new { result = "..." };
        }
    }
@@ -171,10 +173,7 @@ Tools are the user-facing API surface. Exception handling must be explicit, info
 - Catch **specific exception types** (`ArgumentException`, `IOException`, `UnauthorizedAccessException`, etc.)
 - Return structured error objects:
   ```csharp
-  return new {
-      error = "Short description",
-      details = ex.Message
-  };
+  return new ErrorResult("Short description", Hint: "...");
   ```
 - Document expected exceptions in code comments
 
@@ -191,10 +190,7 @@ try {
     var regex = new Regex(pattern);
 }
 catch(ArgumentException ex) {
-    return new {
-        error = "Invalid regex pattern",
-        details = ex.Message
-    };
+    return new ErrorResult($"Invalid regex pattern: {ex.Message}");
 }
 ```
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -9,9 +9,9 @@ Complete setup instructions for all major MCP-compatible AI coding assistants.
 > **⚠️ Not all configurations have been verified in production.**  
 > GitHub Copilot and Claude Desktop are tested and confirmed working. Other clients follow documented MCP patterns but may require adjustments. Contributions and corrections welcome!
 
-> **Configuration reference:** See [Configuration section in README.md](README.md#configuration) for detailed examples and troubleshooting.
+> **Configuration reference:** See [README.md](README.md) for detailed examples and troubleshooting.
 
-> All 28 tools support multi-project workflows via the required `projectPath` parameter. Individual tool calls can target different projects without restarting the server.
+> All 30 tools support multi-project workflows via the required `projectPath` parameter. Individual tool calls can target different projects without restarting the server.
 
 > **Quick start:** Most clients use one of two patterns:
 > - **Workspace config**: `.mcp.json` or similar file in your project root
@@ -344,7 +344,7 @@ RoslynMcp automatically falls back to AdhocWorkspace (source-only mode) if MSBui
 
 ### Multi-project workspaces
 
-All 28 tools require a `projectPath` parameter, enabling multi-project workflows without restarting the server.
+All 30 tools require a `projectPath` parameter, enabling multi-project workflows without restarting the server.
 
 RoslynMcp can analyze multiple projects if they're part of a `.sln` file or linked via `<ProjectReference>`. Point the command-line argument at the solution directory or primary project directory for pre-loading.
 
@@ -398,7 +398,7 @@ For large codebases (>100K LOC), consider:
 
 **Checklist:**
 1. Server process started successfully (check client logs)
-2. MCP session initialized (`tools/list` should return 28 tools)
+2. MCP session initialized (`tools/list` should return 30 tools, or 33 in Debug builds)
 3. Target directory is correct (check server stderr for `Target: ...`)
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 **Give your AI agent a C# compiler instead of grep.**
 ([benchmarks coming](docs/plans/token-benchmark.md) · [shared workspace architecture](docs/plans/multi-instance-architecture.md) · [help wanted](#help-wanted))
 
-RoslynMcp is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI coding agents real Roslyn compiler semantics: type resolution, cross-file references, semantic rename, diagnostics, and 30+ more tools. Not string matching. Not regex. Actual compiler-level understanding of your C# code.
+RoslynMcp is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI coding agents real Roslyn compiler semantics: type resolution, cross-file references, semantic rename, diagnostics, and 30+ tools. Not string matching. Not regex. Actual compiler-level understanding of your C# code.
 
 ```
 Agent: "Rename OrderStatus.Pending to OrderStatus.AwaitingApproval"
@@ -79,7 +79,7 @@ AI agents working on C# through file reads and regex have a structural problem: 
 
 ## Tool Catalog
 
-32 tools organized by what you need to do. All tools work in-process using Roslyn APIs unless noted.
+33 tools organized by what you need to do. All tools work in-process using Roslyn APIs unless noted.
 
 ### Discovery
 


### PR DESCRIPTION
## Summary

Full documentation-to-code sync sweep across 5 files:

- **Tool counts** synced everywhere: README (32→33), AGENTS.md (28→33), INSTALLATION.md (28→30), CHANGELOG (26→33)
- **AGENTS.md** tool table: added 5 missing tools (read_file, get_line_count, insert_lines, change_signature, apply_signature_change); fixed analysis count (13→17) and editing count (2→3)
- **CONTRIBUTING.md**: fixed constructor example (was missing FileLogger + PaginationCache), updated error handling examples from `new { error }` to `ErrorResult`, test count 36→41
- **INSTALLATION.md**: fixed broken `#configuration` anchor, updated tool counts
- **README.md**: "30+ more tools" → "30+ tools", "32 tools" → "33 tools"

## Test plan
- [ ] All doc links resolve
- [ ] Tool counts consistent across all files
- [ ] Code examples in CONTRIBUTING.md match actual patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
