### PR TITLE
fix: LogViewer parser — support PID field + SSE clear marker

### DIFF
--- a/src/RoslynMcp.LogViewer/LogEntry.cs
+++ b/src/RoslynMcp.LogViewer/LogEntry.cs
@@ -13,6 +13,7 @@
 /// <param name="Detail">For TOOL entries: outcome summary, e.g. '18/18 member(s)'.</param>
 record LogEntry(
     string  Timestamp,
+    string? Pid,
     string  Level,
     string  Message,
     string  Raw,

--- a/src/RoslynMcp.LogViewer/LogTailer.cs
+++ b/src/RoslynMcp.LogViewer/LogTailer.cs
@@ -11,9 +11,10 @@ namespace RoslynMcp.LogViewer;
 /// </summary>
 sealed class LogTailer
 {
-	// Format: [14:30:45.123] [TOOL  ] MSB OK      142ms get_type_members         WorkspaceManager — 18/18 member(s)
+	// Format: [14:30:45.123] [12345] [TOOL  ] MSB OK  142ms get_type_members  WorkspaceManager — 18/18 member(s)
+	// Also supports old format without PID: [14:30:45.123] [TOOL  ] ...
 	static readonly Regex LinePattern = new(
-		@"^\[(\d{2}:\d{2}:\d{2}\.\d{3})\] \[(.{6})\] (.*)$",
+		@"^\[(\d{2}:\d{2}:\d{2}\.\d{3})\] (?:\[(\d+)\] )?\[(.{6})\] (.*)$",
 		RegexOptions.Compiled
 	);
 
@@ -231,11 +232,12 @@ sealed class LogTailer
 		var m = LinePattern.Match(raw);
 
 		if(!m.Success)
-			return new LogEntry("", "OTHER", raw, raw);
+			return new LogEntry("", null, "OTHER", raw, raw);
 
 		var timestamp = m.Groups[1].Value;
-		var level     = m.Groups[2].Value.TrimEnd();
-		var message   = m.Groups[3].Value;
+		var pid       = m.Groups[2].Success ? m.Groups[2].Value : null;
+		var level     = m.Groups[3].Value.TrimEnd();
+		var message   = m.Groups[4].Value;
 
 		if(level == "TOOL") {
 
@@ -251,6 +253,7 @@ sealed class LogTailer
 
 				return new LogEntry(
 					Timestamp:     timestamp,
+					Pid:           pid,
 					Level:         level,
 					Message:       message,
 					Raw:           raw,
@@ -264,6 +267,6 @@ sealed class LogTailer
 			}
 		}
 
-		return new LogEntry(timestamp, level, message, raw);
+		return new LogEntry(timestamp, pid, level, message, raw);
 	}
 }

--- a/src/RoslynMcp.LogViewer/ViewerHtml.cs
+++ b/src/RoslynMcp.LogViewer/ViewerHtml.cs
@@ -586,7 +586,13 @@ static class ViewerHtml
 		  };
 
 		  es.onmessage = e => {
-			try { addEntry(JSON.parse(e.data)); }
+			try {
+			  const entry = JSON.parse(e.data);
+			  if(entry.Level === 'INFO' && entry.Message?.toLowerCase().includes('clear'))
+				document.getElementById('clearBtn').click();
+			  else
+				addEntry(entry);
+			}
 			catch { /* malformed entry — skip */ }
 		  };
 


### PR DESCRIPTION
## Summary
- `LogTailer.cs`: update `LinePattern` regex to handle optional `[pid]` field — supports both old and new log format
- `LogEntry.cs`: add `Pid` field
- `ViewerHtml.cs`: SSE clear-on-marker — INFO entries containing "clear" auto-clear the viewer

3 files, 17 lines changed. Fixes #92.

## Test plan
- [ ] LogViewer shows colored/structured output with PID-format log lines
- [ ] LogViewer still works with old-format log lines (no PID)
- [ ] `roslyn_info clear` clears the LogViewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
