### PR TITLE
refactor: migrate error returns to scope.Error() for token estimation

### DIFF
--- a/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/FindImplementationsTool.cs
@@ -73,9 +73,9 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 				));
 			}
 			
-			return new ErrorResult($"'{symbolName}' is not an interface or abstract class.");
+			return scope.Error(new ErrorResult($"'{symbolName}' is not an interface or abstract class."));
 		}
-		
+
 		// Handle method symbols (abstract or virtual).
 		if(symbol is IMethodSymbol methodSymbol) {
 
@@ -108,10 +108,10 @@ internal sealed class FindImplementationsTool : RoslynMcpTool
 				));
 			}
 			
-			return new ErrorResult($"'{symbolName}' is not an abstract, virtual, or override method.");
+			return scope.Error(new ErrorResult($"'{symbolName}' is not an abstract, virtual, or override method."));
 		}
-		
-		return new ErrorResult($"'{symbolName}' is not a type or method — cannot find implementations.");
+
+		return scope.Error(new ErrorResult($"'{symbolName}' is not a type or method — cannot find implementations."));
 	}
 	
 	

--- a/src/RoslynMcp/Tools/Analysis/GetMemberBodyTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetMemberBodyTool.cs
@@ -32,12 +32,12 @@ internal sealed class GetMemberBodyTool : RoslynMcpTool
 		var syntaxRefs = symbol.DeclaringSyntaxReferences;
 
 		if(syntaxRefs.Length == 0)
-			return new MetadataSymbolResult(
+			return scope.Error(new MetadataSymbolResult(
 				FormatSymbolName(symbol),
 				symbol.Kind.ToString().ToLowerInvariant(),
 				"metadata",
 				"This symbol is defined in metadata (compiled assembly), not source code."
-			);
+			));
 
 		var parts = new List<object>();
 

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
@@ -32,12 +32,12 @@ internal sealed class GetSymbolDefinitionTool : RoslynMcpTool
 		var location = symbol.Locations.FirstOrDefault(loc => loc.IsInSource);
 		
 		if(location is null)
-			return new MetadataSymbolResult(
+			return scope.Error(new MetadataSymbolResult(
 				FormatSymbolName(symbol),
 				symbol.Kind.ToString().ToLowerInvariant(),
 				"metadata",
 				"This symbol is defined in metadata (compiled assembly), not source code."
-			);
+			));
 		
 		var span      = location.GetLineSpan();
 		var filePath  = span.Path;

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
@@ -33,12 +33,12 @@ internal sealed class GetSymbolDocumentationTool : RoslynMcpTool
 		var xml = symbol.GetDocumentationCommentXml();
 		
 		if(string.IsNullOrWhiteSpace(xml))
-			return new SymbolDocumentationEmptyResult(
+			return scope.Error(new SymbolDocumentationEmptyResult(
 				FormatSymbolName(symbol),
 				symbol.Kind.ToString().ToLowerInvariant(),
 				null,
 				"No documentation comments found for this symbol."
-			);
+			));
 		
 		var parsed = ParseDocumentation(xml);
 		

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolsInScopeTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolsInScopeTool.cs
@@ -37,7 +37,7 @@ internal sealed class GetSymbolsInScopeTool : RoslynMcpTool
 		var position = GetPosition(text, line, column);
 		
 		if(position < 0)
-			return new ErrorResult($"Line {line}, column {column} is out of range.");
+			return scope.Error(new ErrorResult($"Line {line}, column {column} is out of range."));
 		
 		var model   = compilation.GetSemanticModel(tree);
 		var symbols = model.LookupSymbols(position);

--- a/src/RoslynMcp/Tools/Analysis/GetTriviaTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetTriviaTool.cs
@@ -44,13 +44,13 @@ internal sealed class GetTriviaTool : RoslynMcpTool
             return cachedPage;
 
         if(string.IsNullOrEmpty(filePath))
-            return new ErrorResult("filePath is required unless using listSyntaxKinds or listTriviaKinds");
+            return scope.Error(new ErrorResult("filePath is required unless using listSyntaxKinds or listTriviaKinds"));
 
         if(!TryGetCompilation(projectPath, out var compilation, out var error))
             return error;
 
         if(take <= 0 || take > 500)
-            return new ErrorResult("take must be between 1 and 500");
+            return scope.Error(new ErrorResult("take must be between 1 and 500"));
 
         var normalizedPath = NormalizePath(filePath);
         var tree = compilation.SyntaxTrees.FirstOrDefault(t =>
@@ -58,7 +58,7 @@ internal sealed class GetTriviaTool : RoslynMcpTool
         );
 
         if(tree is null)
-            return new ErrorResult($"File '{filePath}' not found in the compilation.");
+            return scope.Error(new ErrorResult($"File '{filePath}' not found in the compilation."));
 
         var root = tree.GetRoot();
         var sourceText = tree.GetText();
@@ -92,13 +92,13 @@ internal sealed class GetTriviaTool : RoslynMcpTool
 
             if(nodesInSpan.Count == 0) {
 
-                return new GetTriviaNoMatchResult(
+                return scope.Error(new GetTriviaNoMatchResult(
                     "no_matching_nodes",
                     $"No syntax nodes of kind '{syntaxKind}' found in the specified range.",
                     "Use listSyntaxKinds=true to see all available syntax kinds, or check spelling (e.g., 'IfStatement' not 'if').",
                     syntaxKind,
                     GetCommonSyntaxKinds()
-                );
+                ));
             }
         }
 

--- a/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
@@ -33,13 +33,13 @@ internal sealed class SymbolInfoTool : RoslynMcpTool
 		var position = GetPosition(text, line, column);
 
 		if(position < 0)
-			return new ErrorResult($"Line {line}, column {column} is out of range.");
+			return scope.Error(new ErrorResult($"Line {line}, column {column} is out of range."));
 
 		var model = compilation.GetSemanticModel(tree);
 		var node  = (await tree.GetRootAsync()).FindToken(position).Parent;
 
 		if(node is null)
-			return new ErrorResult("No node at that position.");
+			return scope.Error(new ErrorResult("No node at that position."));
 
 		var info   = model.GetSymbolInfo(node);
 		var symbol = info.Symbol ?? info.CandidateSymbols.FirstOrDefault();
@@ -51,7 +51,7 @@ internal sealed class SymbolInfoTool : RoslynMcpTool
 			if(typeInfo.Type is not null)
 				return new SymbolInfoResult("type", typeInfo.Type.ToDisplayString(), null, null);
 
-			return new ErrorResult("No symbol resolved at that position.");
+			return scope.Error(new ErrorResult("No symbol resolved at that position."));
 		}
 
 		return new SymbolInfoResult(

--- a/src/RoslynMcp/Tools/Build/BuildTool.cs
+++ b/src/RoslynMcp/Tools/Build/BuildTool.cs
@@ -48,7 +48,7 @@ internal sealed class BuildTool : RoslynMcpTool
 		var (rootPath, _, csprojPath) = workspace.GetWorkspaceInfo(projectPath);
 		
 		if(csprojPath is null)
-			return new ErrorResult("No .csproj found — build is only available in MSBuildWorkspace mode.");
+			return scope.Error(new ErrorResult("No .csproj found — build is only available in MSBuildWorkspace mode."));
 		
 		// Fast path: check Roslyn diagnostics first (unless forceBuild=true).
 		if(!forceBuild) {
@@ -63,7 +63,7 @@ internal sealed class BuildTool : RoslynMcpTool
 				
 				BuildDiagnostic[] roslynWarnings = [.. roslynDiagnostics.Where(d => d.Severity == "warning")];
 				
-				return new BuildResult(
+				return scope.Error(new BuildResult(
 					Succeeded:     false,
 					Errors:        roslynErrors,
 					Warnings:      roslynWarnings,
@@ -72,7 +72,7 @@ internal sealed class BuildTool : RoslynMcpTool
 					Skip_reason:   "Roslyn reported errors — fix these first, then build will run automatically.",
 					Duration_ms:   0,
 					Exit_code:     null
-				);
+				));
 			}
 		}
 		
@@ -87,8 +87,8 @@ internal sealed class BuildTool : RoslynMcpTool
 			(output, elapsed, exitCode) = await RunDotnetAsync(args, rootPath, scope);
 		}
 		catch(InvalidOperationException ex) {
-			
-			return new BuildResult(
+
+			return scope.Error(new BuildResult(
 				Succeeded:     false,
 				Errors:        (BuildDiagnostic[]) [],
 				Warnings:      (BuildDiagnostic[]) [],
@@ -98,7 +98,7 @@ internal sealed class BuildTool : RoslynMcpTool
 				Duration_ms:   0,
 				Exit_code:     null,
 				Error_details: ex.InnerException?.Message
-			);
+			));
 		}
 		
 		var diagnostics = ParseMSBuildDiagnostics(output, rootPath);

--- a/src/RoslynMcp/Tools/Build/CleanSolutionTool.cs
+++ b/src/RoslynMcp/Tools/Build/CleanSolutionTool.cs
@@ -26,12 +26,12 @@ internal sealed class CleanSolutionTool : RoslynMcpTool
 			projectFile = FindProjectFile(rootPath);
 		}
 		catch(Exception ex) when(ex is UnauthorizedAccessException or DirectoryNotFoundException or IOException) {
-		
-			return new CleanResult(false, "Failed to access project directory.", ex.Message);
+
+			return scope.Error(new CleanResult(false, "Failed to access project directory.", ex.Message));
 		}
-		
+
 		if(projectFile is null)
-			return new CleanResult(false, "No .csproj file found in target directory.", null);
+			return scope.Error(new CleanResult(false, "No .csproj file found in target directory.", null));
 		
 		var startInfo = new ProcessStartInfo
 		{
@@ -50,12 +50,12 @@ internal sealed class CleanSolutionTool : RoslynMcpTool
 			process = Process.Start(startInfo) ?? throw new InvalidOperationException("Process.Start returned null.");
 		}
 		catch(Win32Exception ex) {
-		
-			return new CleanResult(false, "Failed to start dotnet process. Is dotnet installed and in PATH?", ex.Message);
+
+			return scope.Error(new CleanResult(false, "Failed to start dotnet process. Is dotnet installed and in PATH?", ex.Message));
 		}
 		catch(InvalidOperationException ex) {
-		
-			return new CleanResult(false, "Failed to start dotnet clean process.", ex.Message);
+
+			return scope.Error(new CleanResult(false, "Failed to start dotnet clean process.", ex.Message));
 		}
 		
 		string output, error;
@@ -66,8 +66,8 @@ internal sealed class CleanSolutionTool : RoslynMcpTool
 			await process.WaitForExitAsync();
 		}
 		catch(IOException ex) {
-		
-			return new CleanResult(false, "Failed to read process output.", ex.Message);
+
+			return scope.Error(new CleanResult(false, "Failed to read process output.", ex.Message));
 		}
 		
 		var success = process.ExitCode == 0;

--- a/src/RoslynMcp/Tools/Build/RestorePackagesTool.cs
+++ b/src/RoslynMcp/Tools/Build/RestorePackagesTool.cs
@@ -26,12 +26,12 @@ internal sealed class RestorePackagesTool : RoslynMcpTool
 			projectFile = FindProjectFile(rootPath);
 		}
 		catch(Exception ex) when(ex is UnauthorizedAccessException or DirectoryNotFoundException or IOException) {
-		
-			return new RestoreResult(false, "Failed to access project directory.", ex.Message);
+
+			return scope.Error(new RestoreResult(false, "Failed to access project directory.", ex.Message));
 		}
-		
+
 		if(projectFile is null)
-			return new RestoreResult(false, "No .csproj file found in target directory.", null);
+			return scope.Error(new RestoreResult(false, "No .csproj file found in target directory.", null));
 		
 		var startInfo = new ProcessStartInfo
 		{
@@ -50,12 +50,12 @@ internal sealed class RestorePackagesTool : RoslynMcpTool
 			process = Process.Start(startInfo) ?? throw new InvalidOperationException("Process.Start returned null.");
 		}
 		catch(Win32Exception ex) {
-		
-			return new RestoreResult(false, "Failed to start dotnet process. Is dotnet installed and in PATH?", ex.Message);
+
+			return scope.Error(new RestoreResult(false, "Failed to start dotnet process. Is dotnet installed and in PATH?", ex.Message));
 		}
 		catch(InvalidOperationException ex) {
-		
-			return new RestoreResult(false, "Failed to start dotnet restore process.", ex.Message);
+
+			return scope.Error(new RestoreResult(false, "Failed to start dotnet restore process.", ex.Message));
 		}
 		
 		string output, error;
@@ -66,8 +66,8 @@ internal sealed class RestorePackagesTool : RoslynMcpTool
 			await process.WaitForExitAsync();
 		}
 		catch(IOException ex) {
-		
-			return new RestoreResult(false, "Failed to read process output.", ex.Message);
+
+			return scope.Error(new RestoreResult(false, "Failed to read process output.", ex.Message));
 		}
 		
 		var success = process.ExitCode == 0;

--- a/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
+++ b/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
@@ -50,7 +50,7 @@ internal sealed class InsertLinesTool : RoslynMcpTool
 		}
 		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
 
-			return new ErrorResult($"Failed to read file: {ex.Message}");
+			return scope.Error(new ErrorResult($"Failed to read file: {ex.Message}"));
 		}
 
 		// Resolve insertion index (0-based, insert BEFORE this index).
@@ -103,7 +103,7 @@ internal sealed class InsertLinesTool : RoslynMcpTool
 		}
 		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
 
-			return new ErrorResult($"Failed to write file: {ex.Message}");
+			return scope.Error(new ErrorResult($"Failed to write file: {ex.Message}"));
 		}
 
 		workspace.InvalidateFile(projectPath, fullPath);

--- a/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
@@ -46,10 +46,10 @@ internal sealed class ReplaceInCodeTool : RoslynMcpTool
 			return scope.Failed("file not found", new ErrorResult($"File not found: {filePath}"));
 		
 		if(!fullPath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
-			return new ErrorResult("File must be a C# source file (.cs)");
+			return scope.Error(new ErrorResult("File must be a C# source file (.cs)"));
 		
 		if(!TryParseSyntaxKind(nodeKind, out var kind))
-			return new ErrorResult($"Unknown node kind: {nodeKind}.", Hint: "Examples: MethodDeclaration, FieldDeclaration, IdentifierName.");
+			return scope.Error(new ErrorResult($"Unknown node kind: {nodeKind}.", Hint: "Examples: MethodDeclaration, FieldDeclaration, IdentifierName."));
 		
 		SourceText sourceText;
 		
@@ -57,10 +57,10 @@ internal sealed class ReplaceInCodeTool : RoslynMcpTool
 			sourceText = SourceText.From(File.ReadAllText(fullPath));
 		}
 		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
-		
-			return new ErrorResult($"Failed to read file: {ex.Message}");
+
+			return scope.Error(new ErrorResult($"Failed to read file: {ex.Message}"));
 		}
-		
+
 		var syntaxTree = CSharpSyntaxTree.ParseText(sourceText, path: fullPath);
 		var root = await syntaxTree.GetRootAsync();
 		
@@ -85,7 +85,7 @@ internal sealed class ReplaceInCodeTool : RoslynMcpTool
 
 		if(matchedNodes.Length == 0) {
 
-			return new ReplaceInCodeResult(false, 0, [], "No matching nodes found.");
+			return scope.Error(new ReplaceInCodeResult(false, 0, [], "No matching nodes found."));
 		}
 		
 		SyntaxNode? replacementNode;
@@ -117,22 +117,22 @@ internal sealed class ReplaceInCodeTool : RoslynMcpTool
 			};
 			
 			if(replacementNode is null)
-				return new ErrorResult("Failed to parse replacement text — parser returned null");
+				return scope.Error(new ErrorResult("Failed to parse replacement text — parser returned null"));
 			
 			if(replacementNode.ContainsDiagnostics) {
-			
-				return new ReplaceInCodeSyntaxError(
+
+				return scope.Error(new ReplaceInCodeSyntaxError(
 					"Replacement text contains syntax errors",
 					string.Join("; ", replacementNode.GetDiagnostics().Select(d => d.GetMessage()))
-				);
+				));
 			}
 		}
 		catch(Exception ex) {
-		
-			return new ReplaceInCodeSyntaxError(
+
+			return scope.Error(new ReplaceInCodeSyntaxError(
 				"Failed to parse replacement text as valid C# syntax",
 				ex.Message
-			);
+			));
 		}
 		
 		// Collect change info before replacement.
@@ -175,22 +175,22 @@ internal sealed class ReplaceInCodeTool : RoslynMcpTool
 		var syntaxValid = newDiagnostics.Length == 0;
 		
 		if(!syntaxValid) {
-		
-			return new ReplaceInCodeSyntaxError(
+
+			return scope.Error(new ReplaceInCodeSyntaxError(
 				"Replacement would introduce syntax errors",
 				string.Join("; ", newDiagnostics.Select(d => d.GetMessage())),
 				changedNodeInfo
-			);
+			));
 		}
 		
 		try {
 			File.WriteAllText(fullPath, newRoot.ToFullString());
 		}
 		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
-		
-			return new ErrorResult($"Failed to write file: {ex.Message}");
+
+			return scope.Error(new ErrorResult($"Failed to write file: {ex.Message}"));
 		}
-		
+
 		// Invalidate workspace cache
 		workspace.InvalidateFile(projectPath, fullPath);
 		

--- a/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
@@ -62,9 +62,9 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 		}
 		catch(ArgumentException ex) {
 
-			return new ErrorResult($"Invalid regex pattern: {ex.Message}");
+			return scope.Error(new ErrorResult($"Invalid regex pattern: {ex.Message}"));
 		}
-		
+
 		string originalContent;
 		
 		try {
@@ -72,9 +72,9 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 		}
 		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
 
-			return new ErrorResult($"Failed to read file: {ex.Message}");
+			return scope.Error(new ErrorResult($"Failed to read file: {ex.Message}"));
 		}
-		
+
 		// Split into lines to compute 1-based line numbers for each match position.
 		var lines        = originalContent.Split('\n');
 		var lineStarts   = BuildLineStartMap(lines);
@@ -88,7 +88,7 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 		
 		if(matches.Count == 0) {
 
-			return new ReplaceInFileResult(false, 0, [], "No matches found.");
+			return scope.Error(new ReplaceInFileResult(false, 0, [], "No matches found."));
 		}
 		
 		if(dryRun) {
@@ -105,9 +105,9 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 		}
 		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
 
-			return new ErrorResult($"Failed to write file: {ex.Message}");
+			return scope.Error(new ErrorResult($"Failed to write file: {ex.Message}"));
 		}
-		
+
 		// Invalidate the workspace so subsequent Roslyn tools see the updated source.
 		workspace.InvalidateFile(projectPath, fullPath);
 		

--- a/src/RoslynMcp/Tools/Search/ListFilesTool.cs
+++ b/src/RoslynMcp/Tools/Search/ListFilesTool.cs
@@ -47,7 +47,7 @@ internal sealed class ListFilesTool : RoslynMcpTool
 		}
 		catch(Exception ex) when(ex is UnauthorizedAccessException or DirectoryNotFoundException or IOException) {
 
-			return new ErrorResult($"Failed to enumerate files: {ex.Message}");
+			return scope.Error(new ErrorResult($"Failed to enumerate files: {ex.Message}"));
 		}
 
 		var allResults = allFiles
@@ -57,7 +57,7 @@ internal sealed class ListFilesTool : RoslynMcpTool
 		;
 
 		if(allResults.Length == 0)
-			return new ListFilesEmptyResult([], 0, AdhocCaution(projectPath));
+			return scope.Error(new ListFilesEmptyResult([], 0, AdhocCaution(projectPath)));
 
 		var result = PaginateAndStore(allResults, ref skip, take);
 


### PR DESCRIPTION
## Summary

Mechanical migration: all direct `return new ErrorResult(...)` and similar typed error returns now go through `scope.Error(...)`. Ensures token estimation and proper logging on every error path.

14 files, 76 lines changed (1:1 replacements). Depends on #96 for `scope.Error<T>()`. Fixes #94.

**Note:** This PR depends on #96 being merged first (it adds the `scope.Error<T>()` method). Merge #96, then this.

## Test plan
- [ ] Build succeeds (depends on #96)
- [ ] Error paths now show token estimates in LogViewer
- [ ] Test harness passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
