### PR TITLE
feat: experimental PreToolUse hook to enforce roslyn_* tool usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,6 +405,7 @@ docs/github-issues/
 
 # Local utility scripts
 scripts/
+!scripts/enforce-roslyn-tools.sh
 
 # Release artifacts
 RoslynMcp-v*.zip

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ For Claude Code, create `.mcp.json` in your project root:
 ```
 
 > [!IMPORTANT]
-> **Tell your agent to use RoslynMcp.** Agents default to grep and file reads unless you explicitly instruct them. Add a few lines to your project's `CLAUDE.md` or `AGENTS.md` — see [Agent Instructions](#agent-instructions) for a quick example, or [docs/AGENT-INSTRUCTIONS.md](docs/AGENT-INSTRUCTIONS.md) for complete copy-paste instructions covering every tool.
+> **Tell your agent to use RoslynMcp.** Agents default to grep and file reads unless you explicitly instruct them. Add a few lines to your project's `CLAUDE.md` or `AGENTS.md` — see [Agent Instructions](#agent-instructions) for a quick example, or [docs/AGENT-INSTRUCTIONS.md](docs/AGENT-INSTRUCTIONS.md) for complete copy-paste instructions covering every tool. Having trouble getting your agent to comply? See [#99](https://github.com/MadQ/RoslynMcp/issues/99).
+> Claude Code users: try our experimental [PreToolUse hook](scripts/enforce-roslyn-tools.sh) to enforce this automatically.
 
 See [INSTALLATION.md](INSTALLATION.md) for setup guides for GitHub Copilot, Claude Desktop, Cursor, Windsurf, Cline, Continue, Roo Code, Zed, and direct CLI usage.
 
@@ -206,7 +207,7 @@ RoslynMcp works. We use it daily for C# development with AI agents. But it is al
 
 **Large solution testing.** The tool catalog has been tested against small and medium projects. If you have a large real-world codebase (50+ projects, 500K+ lines), we want to know how it performs: load times, memory usage, pagination behavior, anything that breaks.
 
-**Tool description refinements.** The one-line descriptions that agents see determine whether they pick the right tool. If you notice an agent making poor tool choices, a PR that improves a description is a genuinely useful contribution.
+**Making agents choose the right tools.** Agents default to built-in file tools even when roslyn_* tools are available and better. We're working on enforcement hooks, better tool descriptions, and per-client instruction templates — for Claude Code, GitHub Copilot, Cursor, Windsurf, and others. See [#99](https://github.com/MadQ/RoslynMcp/issues/99) for the full wishlist and how to help.
 
 **Multi-agent resource usage.** Each subagent spawns its own MCP server process with its own Roslyn workspace (~100MB+ RAM, ~10s load time). Parallel subagents multiply this cost. We're designing a shared Workspace Service via named pipes — one workspace per solution, shared across all agents. See [#86](https://github.com/MadQ/RoslynMcp/issues/86) and the [design doc](docs/plans/multi-instance-architecture.md).
 

--- a/scripts/enforce-roslyn-tools.sh
+++ b/scripts/enforce-roslyn-tools.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# PreToolUse hook: blocks when Read/Grep/Edit targets a .cs file.
+# The agent should use roslyn_* MCP tools instead.
+# Input: JSON on stdin with tool_name and tool_input.
+
+INPUT=$(cat)
+
+# Extract file_path or path from JSON (no jq, no -P)
+FILE=$(echo "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+
+if [ -z "$FILE" ]; then
+  FILE=$(echo "$INPUT" | sed -n 's/.*"path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+fi
+
+# No file path — allow
+if [ -z "$FILE" ]; then
+  exit 0
+fi
+
+# Extract tool name
+TOOL=$(echo "$INPUT" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+
+# Check if it's a .cs file (case-insensitive)
+if echo "$FILE" | grep -qi '\.cs$'; then
+  echo "{\"decision\":\"block\",\"reason\":\"DOGFOOD! Use roslyn_* tools for .cs files (roslyn_read_file, roslyn_search_files, roslyn_replace_in_file, roslyn_replace_in_code). Only fall back to $TOOL if the RoslynMcp MCP server is disconnected — and if so, state clearly: RoslynMcp disconnected: falling back to $TOOL.\"}"
+fi


### PR DESCRIPTION
## Summary

- **`scripts/enforce-roslyn-tools.sh`** — PreToolUse hook that blocks Read/Grep/Edit on .cs files with an actionable error message pointing to the correct roslyn_* alternative. Includes fallback guidance when MCP is disconnected.
- **README** — `[!IMPORTANT]` callout now links to the hook ("try our experimental PreToolUse hook"). Help Wanted updated to point to #99.
- **`.gitignore`** — exception for the hook script (rest of `scripts/` stays ignored)

Relates to #98, #99.

## Test plan
- [ ] Hook blocks `Read` on a .cs file with clear error message
- [ ] Hook allows `Read` on non-.cs files (README.md, .csproj, etc.)
- [ ] Hook allows `Grep` on non-.cs paths
- [ ] README renders correctly with the callout link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
