### PR TITLE
fix: battle-test findings — scope.Outcome + .slnx Descendants

### DIFF
--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDefinitionTool.cs
@@ -46,7 +46,7 @@ internal sealed class GetSymbolDefinitionTool : RoslynMcpTool
 		var docXml    = symbol.GetDocumentationCommentXml();
 		var docSummary = ExtractDocSummary(docXml);
 		
-		return new SymbolDefinitionResult(
+		return scope.Outcome(symbolName, new SymbolDefinitionResult(
 			FormatSymbolName(symbol),
 			symbol.Kind.ToString().ToLowerInvariant(),
 			relative,
@@ -55,7 +55,7 @@ internal sealed class GetSymbolDefinitionTool : RoslynMcpTool
 			signature,
 			docSummary,
 			AdhocCaution(projectPath)
-		);
+		));
 	}
 	
 	

--- a/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetSymbolDocumentationTool.cs
@@ -42,7 +42,7 @@ internal sealed class GetSymbolDocumentationTool : RoslynMcpTool
 		
 		var parsed = ParseDocumentation(xml);
 		
-		return new SymbolDocumentationResult(
+		return scope.Outcome(symbolName, new SymbolDocumentationResult(
 			FormatSymbolName(symbol),
 			symbol.Kind.ToString().ToLowerInvariant(),
 			parsed.Summary,
@@ -51,7 +51,7 @@ internal sealed class GetSymbolDocumentationTool : RoslynMcpTool
 			parsed.Remarks,
 			parsed.Example,
 			AdhocCaution(projectPath)
-		);
+		));
 	}
 	
 	

--- a/src/RoslynMcp/Tools/Analysis/GetUsingsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetUsingsTool.cs
@@ -49,12 +49,12 @@ internal sealed class GetUsingsTool : RoslynMcpTool
 			? ExtractGlobalUsings(compilation)
 			: [];
 		
-		return new GetUsingsResult(
+		return scope.Outcome(filePath, new GetUsingsResult(
 			Path.GetRelativePath(rootPath, tree.FilePath),
 			usings,
 			globalUsings,
 			AdhocCaution(projectPath)
-		);
+		));
 	}
 	
 	private static string[] ExtractGlobalUsings(Compilation compilation)

--- a/src/RoslynMcp/Tools/Analysis/ProjectInfoTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ProjectInfoTool.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -49,7 +49,7 @@ internal sealed class ProjectInfoTool : RoslynMcpTool
 				.Order()
 		];
 		
-		return new ProjectInfoResult(
+		return scope.Outcome(project.Name, new ProjectInfoResult(
 			project.Name,
 			project.AssemblyName,
 			project.FilePath is not null
@@ -63,7 +63,7 @@ internal sealed class ProjectInfoTool : RoslynMcpTool
 			packages,
 			extraFiles,
 			AdhocCaution(projectPath)
-		);
+		));
 	}
 	
 	private static string? InferTfm(Project project)

--- a/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/SymbolInfoTool.cs
@@ -49,12 +49,12 @@ internal sealed class SymbolInfoTool : RoslynMcpTool
 			var typeInfo = model.GetTypeInfo(node);
 
 			if(typeInfo.Type is not null)
-				return new SymbolInfoResult("type", typeInfo.Type.ToDisplayString(), null, null);
+				return scope.Outcome("type", new SymbolInfoResult("type", typeInfo.Type.ToDisplayString(), null, null));
 
 			return scope.Error(new ErrorResult("No symbol resolved at that position."));
 		}
 
-		return new SymbolInfoResult(
+		return scope.Outcome(symbol.Name, new SymbolInfoResult(
 			symbol.Kind.ToString().ToLowerInvariant(),
 			symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
 			symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
@@ -66,7 +66,7 @@ internal sealed class SymbolInfoTool : RoslynMcpTool
 				_                 => null
 			},
 			AdhocCaution(projectPath)
-		);
+		));
 	}
 
 	private static int GetPosition(SourceText text, int line, int column)

--- a/src/RoslynMcp/Tools/Build/BuildTool.cs
+++ b/src/RoslynMcp/Tools/Build/BuildTool.cs
@@ -106,7 +106,7 @@ internal sealed class BuildTool : RoslynMcpTool
 		BuildDiagnostic[] errors   = [.. diagnostics.Where(d => d.Severity == "error")  ];
 		BuildDiagnostic[] warnings = [.. diagnostics.Where(d => d.Severity == "warning")];
 
-		return new BuildResult(
+		return scope.Outcome("msbuild", new BuildResult(
 			succeeded,
 			errors,
 			warnings,
@@ -115,7 +115,7 @@ internal sealed class BuildTool : RoslynMcpTool
 			Skip_reason:   null,
 			Duration_ms:   (int) elapsed.TotalMilliseconds,
 			Exit_code:     exitCode
-		);
+		));
 	}
 	
 	private static string BuildArgs(string csprojPath, string? tfm)

--- a/src/RoslynMcp/WorkspaceManager.Instance.cs
+++ b/src/RoslynMcp/WorkspaceManager.Instance.cs
@@ -281,7 +281,7 @@ internal sealed partial class WorkspaceManager
 					var slnDir = Path.GetDirectoryName(solutionPath)!;
 
 					var projectPaths = doc.Root!
-						.Elements("Project")
+						.Descendants("Project")
 						.Select(e => e.Attribute("Path")?.Value)
 						.Where(p => p is not null)
 						.Select(p => Path.GetFullPath(Path.Combine(slnDir, p!)))


### PR DESCRIPTION
## Summary

Fixes found during battle-testing against Spectre.Console (26 projects) and Orleans (63 projects):

- **7 success return paths** now go through `scope.Outcome` for token estimation (GetSymbolDefinition, GetSymbolDocumentation, GetUsings, ProjectInfo, SymbolInfo ×2, BuildTool)
- **.slnx parser** — `.Elements("Project")` → `.Descendants("Project")` to find projects nested inside `<Folder>` elements. Orleans has all 63 projects inside folders, zero at top level. Previous behavior: "Solution contains no projects."

## Test plan
- [ ] Build succeeds
- [ ] Token estimates appear in logs for all success paths
- [ ] Orleans .slnx loads (projects inside `<Folder>` elements found)
- [ ] Spectre.Console .slnx still works (mix of top-level and folder-nested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
