### PR TITLE
chore: pre-release doc sweep — tool counts, roslyn_info, battle-test TL;DR

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ This file contains Copilot-specific overrides and notes only.
 
 **All details in [`AGENTS.md`](../AGENTS.md):**
 - Project overview and architecture
-- All 28 tool descriptions
+- All 34 tool descriptions
 - Code style rules (braces, naming, blank lines, etc.)
 - MCP protocol patterns
 - Roslyn API patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ When in doubt: **ask, don't assume.** A thirty-second question beats reverting s
 | **Runtime** | .NET 8 / .NET 10 (net11.0 auto-added when .NET 11 SDK is detected) |
 | **Language** | C# 14 (`<LangVersion>preview</LangVersion>`) |
 | **Version** | 0.7.0-alpha (pre-1.0) |
-| **Tool Count** | 33 MCP tools (27 stable + 2 refactoring + 1 experimental + 3 infrastructure) |
+| **Tool Count** | 34 MCP tools (27 stable + 2 refactoring + 1 experimental + 4 infrastructure) |
 | **Dependencies** | `Microsoft.CodeAnalysis.*` (Roslyn) — MSBuildWorkspace (if .csproj found) → AdhocWorkspace (fallback) |
 | **ImplicitUsings** | `enable` — don't add redundant `using` directives |
 | **Resources** | [C# MCP SDK](https://csharp.sdk.modelcontextprotocol.io/) • [MCP Spec](https://modelcontextprotocol.io/) |
@@ -90,6 +90,7 @@ Use `roslyn_build_project` to build — not `dotnet build` in a terminal.
 | `GetLineCountTool` | `roslyn_get_line_count` — line count for one or more files |
 | `GetMemberBodyTool` | `roslyn_get_member_body` — return full source of a single method/property/field/type by name; handles partial types |
 | `GetTriviaTool` | `roslyn_get_trivia` (**EXPERIMENTAL**) — extract whitespace, comments, and formatting trivia; filter by syntax kind, trivia kind, or line range; useful for understanding indentation context |
+| `InfoTool` | `roslyn_info` — server version, PID, uptime, MSBuild discovery method, log markers |
 | `ApprovalStore` | Session-scoped approval state (`y`, `n`, `session` model) |
 | `SolutionDiff` | Unified diff generation for `Solution` → `Solution` edits |
 
@@ -115,7 +116,9 @@ Use `roslyn_build_project` to build — not `dotnet build` in a terminal.
 **Workspace modes:**
 - **MSBuildWorkspace** (if `.csproj` found) — full NuGet resolution, multi-project support, .NET Framework 4.6.1+ compatibility
 - **AdhocWorkspace** (fallback) — source-only, fast startup (<100 ms)
+- **VS workspace** — uses Visual Studio's MSBuild instance when available
 - See [docs/reference/WORKSPACE_MODES.md](docs/reference/WORKSPACE_MODES.md) for detailed comparison and FAQ
+- **CLI flag:** `--workspace sdk|vs|adhoc|auto` (default: `auto`) — or set `ROSLYNMCP_WORKSPACE` env var to override
 
 **Tool Selection Guidance:**
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,7 +11,7 @@ Complete setup instructions for all major MCP-compatible AI coding assistants.
 
 > **Configuration reference:** See [README.md](README.md) for detailed examples and troubleshooting.
 
-> All 30 tools support multi-project workflows via the required `projectPath` parameter. Individual tool calls can target different projects without restarting the server.
+> All 31 tools support multi-project workflows via the required `projectPath` parameter. Individual tool calls can target different projects without restarting the server.
 
 > **Quick start:** Most clients use one of two patterns:
 > - **Workspace config**: `.mcp.json` or similar file in your project root
@@ -344,7 +344,7 @@ RoslynMcp automatically falls back to AdhocWorkspace (source-only mode) if MSBui
 
 ### Multi-project workspaces
 
-All 30 tools require a `projectPath` parameter, enabling multi-project workflows without restarting the server.
+All 31 tools require a `projectPath` parameter, enabling multi-project workflows without restarting the server.
 
 RoslynMcp can analyze multiple projects if they're part of a `.sln` file or linked via `<ProjectReference>`. Point the command-line argument at the solution directory or primary project directory for pre-loading.
 
@@ -398,7 +398,7 @@ For large codebases (>100K LOC), consider:
 
 **Checklist:**
 1. Server process started successfully (check client logs)
-2. MCP session initialized (`tools/list` should return 30 tools, or 33 in Debug builds)
+2. MCP session initialized (`tools/list` should return 31 tools, or 34 in Debug builds)
 3. Target directory is correct (check server stderr for `Target: ...`)
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 **Give your AI agent a C# compiler instead of grep.**
 ([first battle-test results: 38-69% token savings, bugs found, lessons learned](docs/battle-test-results.md) · [shared workspace architecture](docs/plans/multi-instance-architecture.md) · [help wanted](#help-wanted))
 
-RoslynMcp is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI coding agents real Roslyn compiler semantics: type resolution, cross-file references, semantic rename, diagnostics, and 30+ tools. Not string matching. Not regex. Actual compiler-level understanding of your C# code.
+RoslynMcp is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI coding agents real Roslyn compiler semantics: type resolution, cross-file references, semantic rename, diagnostics, and 34 tools. Not string matching. Not regex. Actual compiler-level understanding of your C# code.
 
 ```
 Agent: "Rename OrderStatus.Pending to OrderStatus.AwaitingApproval"
@@ -80,7 +80,7 @@ AI agents working on C# through file reads and regex have a structural problem: 
 
 ## Tool Catalog
 
-33 tools organized by what you need to do. All tools work in-process using Roslyn APIs unless noted.
+34 tools organized by what you need to do. All tools work in-process using Roslyn APIs unless noted.
 
 ### Discovery
 
@@ -141,6 +141,12 @@ AI agents working on C# through file reads and regex have a structural problem: 
 | `roslyn_build_project` | Smart build: Roslyn diagnostics first, MSBuild only if clean |
 | `roslyn_clean_solution` | Remove all build artifacts |
 | `roslyn_restore_packages` | Restore NuGet packages |
+
+### Diagnostics & Info
+
+| Tool | What it does |
+|------|--------------|
+| `roslyn_info` | Server version, PID, uptime, MSBuild discovery, log markers |
 
 ---
 

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -99,6 +99,11 @@ built-in tools only if a roslyn tool fails.
   updating.
 - `roslyn_clean_solution` — Run `dotnet clean`. Use when build artifacts need
   clearing.
+
+### Diagnostics & Info
+
+- `roslyn_info` — Server version, PID, uptime, MSBuild discovery method, and
+  log markers. Use to verify the server is running and check its configuration.
 ```
 
 ---
@@ -123,6 +128,7 @@ are more accurate than grep/Read/Edit.
 - Rename: `roslyn_preview_rename` + `roslyn_apply_rename` > find-and-replace
 - Build: `roslyn_build_project` > NEVER `dotnet build` in terminal
 - Diagnostics: `roslyn_get_diagnostics` for fast error checks
+- Info: `roslyn_info` for server version, PID, uptime, MSBuild discovery
 ```
 
 ---
@@ -154,6 +160,7 @@ Specific alternatives for common tasks:
 - Insert lines:   roslyn_insert_lines (not Edit)
 - Build:          roslyn_build_project (NEVER dotnet build in terminal)
 - Diagnostics:    roslyn_get_diagnostics
+- Server info:    roslyn_info (version, PID, uptime, MSBuild discovery)
 
 Violation triggers permission prompts that block the user.
 ```

--- a/docs/battle-test-results.md
+++ b/docs/battle-test-results.md
@@ -11,6 +11,18 @@ We tested RoslynMcp against three repos with the same prompts, with and without 
 
 ---
 
+## TL;DR
+
+- **38-69% fewer tokens** on refactoring and editing workflows
+- **18x faster build verification** (milliseconds vs minutes)
+- **Semantic rename: 60% fewer tokens**, atomic, zero risk
+- **Cheap model parity**: Haiku + roslyn tools = same correctness as Sonnet
+- **Built-in tools won** on exploration richness and simple grep-friendly tasks
+- **We found real bugs in Orleans** -- both approaches found different ones
+- **Cold start is real**: 22s (adhoc) to 7min (MSBuild) for large solutions. Now configurable via `--workspace adhoc`.
+
+---
+
 ## The Numbers
 
 ### Spectre.Console (26 projects) — 7 tests
@@ -91,7 +103,7 @@ The built-in tools agent found a more impactful bug (ToString() dropping stack t
 
 **RoslynMcp's tools need improvement for:** exploration (richer responses needed), type hierarchy (missing per-type details), find_references (needs context snippets), and "awareness" of related members the agent didn't ask about.
 
-**The cold start problem is real.** 7 minutes for Orleans (235 compiled projects) is painful. The adhoc fallback works (~20s) but loses MSBuild semantics. We need the `workspaceMode` parameter (#101) and the large-solution heuristic.
+**The cold start problem is real.** 7 minutes for Orleans (235 compiled projects) is painful. The `--workspace adhoc` option (shipped in #104) reduced Orleans load time from 7 minutes to 22 seconds. Now configurable via `--workspace sdk|vs|adhoc|auto` or the `ROSLYNMCP_WORKSPACE` env var.
 
 **Token savings are real but not universal.** 38-69% savings on refactoring/editing workflows. Modest savings on exploration (25-44%). Grep wins on simple unique-name searches. The headline is NOT "X% fewer tokens on everything" — it's "dramatically fewer tokens where it matters most, and comparable or slightly more where it doesn't."
 
@@ -103,7 +115,7 @@ The built-in tools agent found a more impactful bug (ToString() dropping stack t
 1. `.slnx` parser missed `<Folder>`-nested projects (`.Elements` → `.Descendants`)
 2. `ResolveProjectPath` doesn't handle `.slnx` input
 3. Path resolution requires absolute paths — agents always try relative first
-4. 7-minute cold start on large solutions — needs `workspaceMode` option
+4. 7-minute cold start on large solutions — now configurable via `--workspace adhoc` (shipped in #104)
 5. `scope.Outcome` missing on several success paths
 6. `roslyn_insert_lines` never chosen by agents — description needs improvement
 7. Multi-line `roslyn_replace_in_file` patterns still broken (CRLF in MCP JSON)
@@ -120,7 +132,7 @@ The built-in tools agent found a more impactful bug (ToString() dropping stack t
 1. **Enrich `find_references`** — add context snippets per reference
 2. **Enrich `get_type_hierarchy`** — per-type interfaces, intermediate base classes
 3. **"Awareness hints"** — note related overrides (ToString, Dispose, etc.) when returning member bodies
-4. **`workspaceMode` parameter** — opt-in adhoc for large solutions (#101)
+4. **~~`workspaceMode` parameter~~** — shipped in #104 as `--workspace adhoc`
 5. **Smarter `projectPath` resolution** — handle .slnx, try CWD-relative, search by filename
 6. **`roslyn_replace_body`** — replace method body only, keep signature intact
 7. **Diagnostics grouping** — `groupBy: "code"` for summarized error/warning view

--- a/docs/process/DOC_REVIEW_CHECKLIST.md
+++ b/docs/process/DOC_REVIEW_CHECKLIST.md
@@ -34,7 +34,7 @@ rg "RoslynMcp/RoslynMcp\.csproj" --type md --glob "!HANDOFF*.md"
 # 2. Check for dotnet run in MCP configs (should use published executable)
 rg "dotnet.*run.*--project.*\.mcp\.json" --type md -A 3 -B 3
 
-# 3. Verify tool count is consistent (should be 28 tools currently)
+# 3. Verify tool count is consistent (should be 34 tools currently, 31 public + 3 debug-only)
 rg "23 tools|22 tools|21 tools" --type md
 
 # 4. Check for stale "deferred" or "planned" features that shipped
@@ -64,7 +64,7 @@ rg "TestHarness/TestHarness\.csproj" --type md | rg -v "src/TestHarness"
   - [ ] AGENTS.md
   - [ ] `docs/sessions/HANDOFF.md` header
   - [ ] TestHarness header comment
-- [ ] Architecture tables list all 28 tools consistently
+- [ ] Architecture tables list all 34 tools consistently
 - [ ] New tools added to all relevant docs
 
 ### Code Examples
@@ -112,7 +112,7 @@ rg "TestHarness/TestHarness\.csproj" --type md | rg -v "src/TestHarness"
 - [ ] Examples are copy-paste ready
 
 ### AGENTS.md
-- [ ] Architecture table has all 28 tools
+- [ ] Architecture table has all 34 tools
 - [ ] Code style rules are current
 - [ ] MCP/Roslyn patterns are accurate
 - [ ] Testing section references correct paths

--- a/docs/reference/WORKSPACE_MODES.md
+++ b/docs/reference/WORKSPACE_MODES.md
@@ -146,7 +146,7 @@ You don't manually "switch" modes—RoslynMcp detects the mode per project path.
 
 ### Multi-Project Workflows (v0.3.0+)
 
-All 28 tools require a `projectPath` parameter, so you can work with **both modes in a single session**:
+All 31 tools require a `projectPath` parameter, so you can work with **both modes in a single session**:
 
 ```json
 // Example: workspace with both project types

--- a/scripts/enforce-roslyn-tools.sh
+++ b/scripts/enforce-roslyn-tools.sh
@@ -22,5 +22,5 @@ TOOL=$(echo "$INPUT" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\
 
 # Check if it's a .cs file (case-insensitive)
 if echo "$FILE" | grep -qi '\.cs$'; then
-  echo "{\"decision\":\"block\",\"reason\":\"DOGFOOD! Use roslyn_* tools for .cs files (roslyn_read_file, roslyn_search_files, roslyn_replace_in_file, roslyn_replace_in_code). Only fall back to $TOOL if the RoslynMcp MCP server is disconnected — and if so, state clearly: RoslynMcp disconnected: falling back to $TOOL.\"}"
+  echo "{\"decision\":\"block\",\"reason\":\"Use roslyn_* MCP tools for .cs files (roslyn_read_file, roslyn_search_files, roslyn_replace_in_file, roslyn_replace_in_code). Only fall back to $TOOL if the RoslynMcp MCP server is disconnected — and if so, state clearly: RoslynMcp disconnected: falling back to $TOOL.\"}"
 fi

--- a/src/TestHarness/TestHarnessProgram.cs
+++ b/src/TestHarness/TestHarnessProgram.cs
@@ -69,7 +69,7 @@ async Task SendAsync(object payload)
 	await writer.FlushAsync();
 }
 
-async Task<JsonNode?> ReceiveAsync(int timeoutMs = 30_000)
+async Task<JsonNode?> ReceiveAsync(int timeoutMs = 60_000)
 {
 	using var cts = new CancellationTokenSource(timeoutMs);
 	


### PR DESCRIPTION
## Summary

Pre-release documentation sweep — syncs all docs with current codebase.

- **Tool counts**: 28/30/33 → 34 across 8 doc files
- **roslyn_info**: added to tool catalog (README), architecture table (AGENTS.md), agent instructions, compact version, subagent prompt
- **Workspace mode**: added --workspace sdk|vs|adhoc|auto docs to AGENTS.md
- **Battle-test results**: TL;DR section added, workspace mode status updated (now shipped, 7min→22s)
- **Enforcement hook**: removed "DOGFOOD!" wording (doesn't make sense outside the project)
- **Test harness**: timeout 30s→60s for change_signature test (#105)
- **Copilot instructions**: 28→34 tools

10 files changed.

## Test plan
- [ ] No remaining "28 tools" / "30 tools" / "33 tools" references in docs
- [ ] roslyn_info appears in README, AGENTS.md, AGENT-INSTRUCTIONS.md
- [ ] Battle-test TL;DR renders correctly
- [ ] Test harness passes (40/41, #105 known)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
