### PR TITLE
fix: path resolution safety — separator guard + ambiguity detection

### DIFF
--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -372,9 +372,9 @@ internal abstract partial class RoslynMcpTool
 			string? nameHit   = null;
 			var     ambiguous = false;
 			
-			try {
-				foreach(var candidate in Directory.EnumerateFiles(rootPath, fileName, SearchOption.AllDirectories)) {
-					
+			foreach(var candidate in Directory.EnumerateFiles(rootPath, fileName, SearchOption.AllDirectories)) {
+				
+				try {
 					if(candidate.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) {
 						
 						if(suffixHit is not null) {
@@ -392,8 +392,10 @@ internal abstract partial class RoslynMcpTool
 							nameHit = candidate;
 					}
 				}
+				catch(Exception ex) when(ex is ArgumentException or IOException or UnauthorizedAccessException) {
+					// Skip this candidate and keep enumerating.
+				}
 			}
-			catch(Exception ex) when(ex is ArgumentException or IOException or UnauthorizedAccessException) { }
 			
 			if(!ambiguous && suffixHit is not null)
 				return suffixHit;

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -372,20 +372,34 @@ internal abstract partial class RoslynMcpTool
 			string? nameHit   = null;
 			var     ambiguous = false;
 			
-			foreach(var candidate in Directory.EnumerateFiles(rootPath, fileName, SearchOption.AllDirectories)) {
-				
-				if(candidate.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) {
-					if(suffixHit is not null) { ambiguous = true; break; }
-					suffixHit = candidate;
-				}
-				else if(string.Equals(Path.GetFileName(candidate), fileName, StringComparison.OrdinalIgnoreCase)) {
-					if(nameHit is not null) nameHit = null; // >1 filename match → discard
-					else nameHit = candidate;
+			try {
+				foreach(var candidate in Directory.EnumerateFiles(rootPath, fileName, SearchOption.AllDirectories)) {
+					
+					if(candidate.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) {
+						
+						if(suffixHit is not null) {
+							ambiguous = true;
+							break;
+						}
+						
+						suffixHit = candidate;
+					}
+					else if(string.Equals(Path.GetFileName(candidate), fileName, StringComparison.OrdinalIgnoreCase)) {
+						
+						if(nameHit is not null)
+							nameHit = null; // >1 filename match → discard
+						else
+							nameHit = candidate;
+					}
 				}
 			}
+			catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) { }
 			
-			if(!ambiguous && suffixHit is not null) return suffixHit;
-			if(nameHit is not null) return nameHit;
+			if(!ambiguous && suffixHit is not null)
+				return suffixHit;
+			
+			if(nameHit is not null)
+				return nameHit;
 		}
 		catch(Exception ex) when(ex is ArgumentException or IOException or UnauthorizedAccessException) { }
 		

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -393,7 +393,7 @@ internal abstract partial class RoslynMcpTool
 					}
 				}
 			}
-			catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) { }
+			catch(Exception ex) when(ex is ArgumentException or IOException or UnauthorizedAccessException) { }
 			
 			if(!ambiguous && suffixHit is not null)
 				return suffixHit;

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -363,14 +363,29 @@ internal abstract partial class RoslynMcpTool
 				return direct;
 			
 			// Fallback: suffix match — handles agents passing project-relative paths
-			// when rootPath is the solution directory.
-			var suffix = Path.DirectorySeparatorChar + normalized;
+			// when rootPath is the solution directory. Prefer strict suffix matches
+			// over bare filename matches, and return null on ambiguity rather than
+			// silently picking an arbitrary file.
+			var suffix        = Path.DirectorySeparatorChar + normalized;
+			var fileName      = Path.GetFileName(normalized);
+			string? suffixHit = null;
+			string? nameHit   = null;
+			var     ambiguous = false;
 			
-			foreach(var candidate in Directory.EnumerateFiles(rootPath, Path.GetFileName(normalized), SearchOption.AllDirectories)) {
+			foreach(var candidate in Directory.EnumerateFiles(rootPath, fileName, SearchOption.AllDirectories)) {
 				
-				if(candidate.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) || string.Equals(Path.GetFileName(candidate), Path.GetFileName(normalized), StringComparison.OrdinalIgnoreCase))
-					return candidate;
+				if(candidate.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) {
+					if(suffixHit is not null) { ambiguous = true; break; }
+					suffixHit = candidate;
+				}
+				else if(string.Equals(Path.GetFileName(candidate), fileName, StringComparison.OrdinalIgnoreCase)) {
+					if(nameHit is not null) nameHit = null; // >1 filename match → discard
+					else nameHit = candidate;
+				}
 			}
+			
+			if(!ambiguous && suffixHit is not null) return suffixHit;
+			if(nameHit is not null) return nameHit;
 		}
 		catch(Exception ex) when(ex is ArgumentException or IOException or UnauthorizedAccessException) { }
 		
@@ -394,8 +409,10 @@ internal abstract partial class RoslynMcpTool
 			
 			if(Path.IsPathRooted(filePath)) {
 				
-				// Absolute path — verify it stays under root.
-				if(!filePath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase)) {
+				// Absolute path — verify it stays under root with separator guard
+				// to prevent prefix collisions (e.g. root "D:\Foo" matching "D:\FooBar\file.cs").
+				if(!filePath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase) ||
+					(filePath.Length > rootPath.Length && filePath[rootPath.Length] is not '\\' and not '/')) {
 					
 					error = $"Path '{filePath}' is outside the project root.";
 					


### PR DESCRIPTION
## Summary
- **Path traversal separator guard** (item 4, high): `TryResolveTargetPath` absolute-path branch now checks for a directory separator after the root prefix, preventing `D:\Foo` from matching `D:\FooBar\secret.cs`. Mirrors the guard already present in the relative-path branch.
- **Suffix match ambiguity detection** (item 7, medium): `ResolveFilePath` fallback now collects all candidates and returns `null` on ambiguity instead of silently returning the first filesystem hit. Strict suffix matches are preferred over bare filename matches.

Closes #145 items 4, 7.

## Test plan
- [ ] Verify clean build (`roslyn_build_project` ✅)
- [ ] Confirm `ResolveFilePath` still resolves unambiguous files normally
- [ ] Confirm ambiguous filenames (e.g. `Helpers.cs` in two projects) return "file not found" instead of picking one silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
