### PR TITLE
fix: analysis tool accuracy — call graph constructors + diagnostic dedup

### DIFF
--- a/src/RoslynMcp/Tools/Analysis/DiagnosticsTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/DiagnosticsTool.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using ModelContextProtocol.Server;
@@ -65,8 +65,11 @@ internal sealed class DiagnosticsTool : RoslynMcpTool
 				.Where(d => IsUnderRoot(d, rootPath))
 			;
 		
+		// Deduplicate by identity tuple — multi-TFM workspaces can surface the same
+		// diagnostic from duplicate document entries across target frameworks.
 		var filtered = diagnostics
 			.Where(GetSeverityFilter(severity))
+			.DistinctBy(d => (d.Id, d.Location.SourceTree?.FilePath, d.Location.GetLineSpan().StartLinePosition.Line, d.Location.GetLineSpan().StartLinePosition.Character, d.GetMessage()))
 			.OrderByDescending(d => d.Severity)
 			.ThenBy(d => d.Location.SourceTree?.FilePath)
 			.ThenBy(d => d.Location.GetLineSpan().StartLinePosition.Line)

--- a/src/RoslynMcp/Tools/Analysis/GetCallGraphTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetCallGraphTool.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 using ModelContextProtocol.Server;
@@ -53,16 +53,24 @@ internal sealed class GetCallGraphTool : RoslynMcpTool
 			if(operation is null)
 				continue;
 
-			foreach(var invocation in operation.DescendantsAndSelf().OfType<IInvocationOperation>()) {
+			foreach(var descendant in operation.DescendantsAndSelf()) {
 
-				var loc  = invocation.Syntax.GetLocation();
+				ISymbol? callee = descendant switch {
+					IInvocationOperation inv       => inv.TargetMethod,
+					IObjectCreationOperation ctor  => ctor.Constructor,
+					_ => null
+				};
+				
+				if(callee is null) continue;
+
+				var loc  = descendant.Syntax.GetLocation();
 				var span = loc.GetLineSpan();
 				var file = span.Path is { Length: > 0 } p
 					? Path.GetRelativePath(rootPath, p)
 					: "?";
 
 				allCalls.Add(new CallSiteEntry(
-					Callee: FormatSymbolName(invocation.TargetMethod),
+					Callee: FormatSymbolName(callee),
 					File:   file,
 					Line:   span.StartLinePosition.Line + 1
 				));

--- a/src/RoslynMcp/Tools/Analysis/GetCallGraphTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetCallGraphTool.cs
@@ -61,7 +61,8 @@ internal sealed class GetCallGraphTool : RoslynMcpTool
 					_ => null
 				};
 				
-				if(callee is null) continue;
+				if(callee is null)
+					continue;
 
 				var loc  = descendant.Syntax.GetLocation();
 				var span = loc.GetLineSpan();


### PR DESCRIPTION
## Summary
- **Call graph captures constructors** (item 5, high): `GetCallGraphTool` now walks `IObjectCreationOperation` in addition to `IInvocationOperation`, so `new Foo()` calls appear in the graph — matching the documented claim "Includes constructors".
- **Diagnostic deduplication** (item 13, low): `DiagnosticsTool` deduplicates by `(code, file, line, column, message)` to prevent identical entries from multi-TFM document duplicates.

Closes #145 items 5, 13.

## Test plan
- [ ] Verify clean build (`roslyn_build_project` ✅)
- [ ] `roslyn_get_call_graph` on a method containing `new Foo()` — verify constructor appears in results
- [ ] `roslyn_get_diagnostics` on a multi-TFM project — verify no duplicate entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
