### PR TITLE
fix: editing tools & backup store — line endings, AsyncLocal, backups, token uniqueness

### DIFF
--- a/src/RoslynMcp/BackupStore.cs
+++ b/src/RoslynMcp/BackupStore.cs
@@ -89,7 +89,10 @@ internal sealed class BackupStore
 		var pathHash = ComputePathHash(absolutePath);
 		var dir      = Path.Combine(backupRoot, pathHash);
 		var unixMs   = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-		var token    = $"{pathHash}_{unixMs}";
+		// Append a short random suffix to guarantee uniqueness even when two backups
+		// of the same file land within the same millisecond (Windows timer resolution ~15ms).
+		var nonce    = Guid.NewGuid().ToString("N")[..4];
+		var token    = $"{pathHash}_{unixMs}_{nonce}";
 
 		// Read git context outside the lock — avoids holding it during file I/O.
 		var (gitBranch, gitCommit) = ReadGitContext(absolutePath);
@@ -99,7 +102,7 @@ internal sealed class BackupStore
 
 				Directory.CreateDirectory(dir);
 
-				var bakFile  = Path.Combine(dir, $"{Path.GetFileName(absolutePath)}_{unixMs}.bak");
+				var bakFile  = Path.Combine(dir, $"{Path.GetFileName(absolutePath)}_{unixMs}_{nonce}.bak");
 				var metaFile = Path.Combine(dir, MetaFileName);
 
 				FileWriter.WriteAllBytes(bakFile, current);
@@ -182,7 +185,8 @@ internal sealed class BackupStore
 
 		var parts = token.Split('_');
 
-		if(parts.Length != 2)
+		// Token format: {pathHash}_{unixMs} (legacy) or {pathHash}_{unixMs}_{nonce}.
+		if(parts.Length < 2)
 			return (RestoreResult.InvalidToken(token), null);
 
 		var dir      = Path.Combine(backupRoot, parts[0]);
@@ -197,8 +201,9 @@ internal sealed class BackupStore
 
 			try {
 
-				var ms      = parts[1];
-				var bakFile = Directory.EnumerateFiles(dir, $"*_{ms}.bak").FirstOrDefault();
+				// Extract the suffix after the path hash (covers both legacy "ms" and new "ms_nonce" formats).
+				var suffix  = token[(parts[0].Length + 1)..];
+				var bakFile = Directory.EnumerateFiles(dir, $"*_{suffix}.bak").FirstOrDefault();
 
 				if(bakFile is null)
 					return (RestoreResult.NotFound(token), null);
@@ -245,6 +250,11 @@ internal sealed class BackupStore
 	///     Attempts to restore a file from the backup identified by <paramref name="token"/>.
 	///     Returns a <see cref="RestoreResult"/> describing success, conflict, or failure.
 	/// </summary>
+	/// <remarks>
+	///     Bypasses WorkspaceManager — the workspace will be out of sync until FSW fires.
+	///     Prefer the TryCheck / WriteAndInvalidate / CompleteRestore split used by LocalHistoryTool.
+	/// </remarks>
+	[Obsolete("Use TryCheck + WriteAndInvalidate + CompleteRestore instead — this method bypasses WorkspaceManager.")]
 	public RestoreResult TryRestore(string token, bool force = false)
 	{
 		var (failure, checkedRestore) = TryCheck(token, force);
@@ -427,9 +437,10 @@ internal sealed class BackupStore
 			ordered.RemoveAt(0);
 			entries.Remove(oldToken);
 
-			// Delete matching .bak file.
-			var ms      = oldToken.Split('_').LastOrDefault() ?? "";
-			var bakFile = Directory.EnumerateFiles(dir, $"{fileName}_{ms}.bak").FirstOrDefault();
+			// Delete matching .bak file — extract suffix after path hash.
+			var hashEnd = oldToken.IndexOf('_');
+			var suffix  = hashEnd >= 0 ? oldToken[(hashEnd + 1)..] : oldToken;
+			var bakFile = Directory.EnumerateFiles(dir, $"{fileName}_{suffix}.bak").FirstOrDefault();
 
 			if(bakFile is not null)
 				File.Delete(bakFile);
@@ -491,7 +502,7 @@ internal sealed class RestoreResult
 		=> new() { ErrorMessage = $"No backup found for token '{token}'." };
 
 	public static RestoreResult InvalidToken(string token)
-		=> new() { ErrorMessage = $"Invalid token format: '{token}'. Expected {{path-hash}}_{{unix-ms}}." };
+		=> new() { ErrorMessage = $"Invalid token format: '{token}'. Expected {{path-hash}}_{{unix-ms}}_{{nonce}}." };
 
 	public static RestoreResult Failed(string message)
 		=> new() { ErrorMessage = message };

--- a/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
+++ b/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
@@ -7,8 +7,10 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class InsertLinesTool : RoslynMcpTool
 {
-	public InsertLinesTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache)
-		: base(workspace, logger, paginationCache) { }
+	readonly BackupStore backups;
+	
+	public InsertLinesTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache, BackupStore backups)
+		: base(workspace, logger, paginationCache) { this.backups = backups; }
 	
 	[McpServerTool(Name = "roslyn_insert_lines", Destructive = false, Title = "Insert Lines", OpenWorld = false)]
 		[Description(
@@ -50,14 +52,24 @@ internal sealed class InsertLinesTool : RoslynMcpTool
 		if(specCount > 1)
 			return scope.Failed("multiple locations", new ErrorResult("Specify only one of: atLine, insertAfter, or insertBefore."));
 		
+		string   rawContent;
 		string[] lines;
 		
 		try {
-			lines = File.ReadAllLines(fullPath);
+			rawContent = File.ReadAllText(fullPath);
 		}
 		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) {
 			return scope.Error(new ErrorResult($"Failed to read file: {ex.Message}"));
 		}
+		
+		// Detect existing line-ending style before splitting strips them.
+		var eol = rawContent.Contains("\r\n") ? "\r\n" : "\n";
+		lines   = rawContent.Split(["\r\n", "\n"], StringSplitOptions.None);
+		
+		// Split produces a trailing empty element when the file ends with a newline — trim it
+		// so the insertion index math stays consistent with File.ReadAllLines behavior.
+		if(lines.Length > 0 && lines[^1].Length == 0)
+			lines = lines[..^1];
 		
 		// Resolve insertion index (0-based, insert BEFORE this index).
 		int insertIndex;
@@ -103,12 +115,14 @@ internal sealed class InsertLinesTool : RoslynMcpTool
 			return scope.Outcome("dry run", new InsertLinesResult(false, insertIndex + 1, newLines.Length, insertedLines,
 				$"Dry run: {newLines.Length} line(s) would be inserted at line {insertIndex + 1}."));
 		
+		backups.Save(fullPath, projectPath, "roslyn_insert_lines", FileWriter.Utf8NoBom.GetBytes(string.Join(eol, resultLines) + eol));
+		
 		// For .cs files: single write via workspace API with FSW suppression.
 		// For all other types: direct FileWriter write, then InvalidateFile.
 		if(fullPath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)) {
 			
-			// WriteAllLines uses Environment.NewLine + trailing newline; match that here.
-			var resultText = string.Join(Environment.NewLine, resultLines) + Environment.NewLine;
+			// Preserve the file's original line-ending style.
+			var resultText = string.Join(eol, resultLines) + eol;
 			
 			try {
 				await workspace.ApplyTextChange(projectPath, fullPath, SourceText.From(resultText, FileWriter.Utf8NoBom));
@@ -120,7 +134,9 @@ internal sealed class InsertLinesTool : RoslynMcpTool
 		else {
 			
 			try {
-				FileWriter.WriteAllLines(fullPath, resultLines);
+				// Preserve original line-ending style instead of using Environment.NewLine.
+				var resultText = string.Join(eol, resultLines) + eol;
+				FileWriter.WriteAllText(fullPath, resultText);
 			}
 			catch(Exception ex) when(ex is IOException or UnauthorizedAccessException or NotSupportedException) {
 				return scope.Error(new ErrorResult($"Failed to write file: {ex.Message}"));

--- a/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
@@ -16,7 +16,9 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class ReplaceInCodeTool : RoslynMcpTool
 {
-	public ReplaceInCodeTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
+	readonly BackupStore backups;
+	
+	public ReplaceInCodeTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache, BackupStore backups) : base(workspace, logger, paginationCache) { this.backups = backups; }
 	
 	[McpServerTool(Name = "roslyn_replace_in_code", Destructive = true, Title = "Replace In Code", OpenWorld = false)]
 		[Description(
@@ -144,6 +146,8 @@ internal sealed class ReplaceInCodeTool : RoslynMcpTool
 				));
 			}
 			
+			backups.Save(fullPath, projectPath, "roslyn_replace_in_code", FileWriter.Utf8NoBom.GetBytes(deletedRoot.ToFullString()));
+			
 			// When the document is workspace-tracked, let Roslyn write it via TryApplyChanges
 			// (MSBuild only — handles FSW suppression and encoding). Fall back to direct I/O
 			// for untracked files (e.g. AdhocWorkspace or files outside the project).
@@ -241,6 +245,8 @@ internal sealed class ReplaceInCodeTool : RoslynMcpTool
 				string.Join("; ", newDiagnostics.Select(d => d.GetMessage())),
 				changedNodeInfo
 			));
+		
+		backups.Save(fullPath, projectPath, "roslyn_replace_in_code", FileWriter.Utf8NoBom.GetBytes(newRoot.ToFullString()));
 		
 		// When the document is workspace-tracked, let Roslyn write it via TryApplyChanges
 		// (MSBuild only — handles FSW suppression and encoding). Fall back to direct I/O

--- a/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
@@ -8,7 +8,9 @@ namespace RoslynMcp.Tools;
 [McpServerToolType]
 internal sealed class ReplaceInFileTool : RoslynMcpTool
 {
-	public ReplaceInFileTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache) : base(workspace, logger, paginationCache) { }
+	readonly BackupStore backups;
+	
+	public ReplaceInFileTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache, BackupStore backups) : base(workspace, logger, paginationCache) { this.backups = backups; }
 	
 	[McpServerTool(Name = "roslyn_replace_in_file", Destructive = true, Title = "Replace In File", OpenWorld = false)]
 		[Description(
@@ -95,6 +97,8 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 		
 		var effectiveReplacement = normalizeLineEndings ? NormalizeLineEndings(replacement, originalContent) : replacement;
 		var newContent = regex.Replace(originalContent, effectiveReplacement);
+		
+		backups.Save(fullPath, projectPath, "roslyn_replace_in_file", FileWriter.Utf8NoBom.GetBytes(newContent));
 		
 		// For .cs files: single write via workspace API (MSBuild-tracked goes through
 		// TryApplyChanges; untracked/Adhoc goes through FileWriter with FSW suppressed).

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -16,8 +16,9 @@ internal abstract partial class RoslynMcpTool
 	
 	// Tracks the in-flight scope so TryGetCompilation/TryGetProject can set workspace mode without
 	// requiring callers to thread the scope through as a parameter.
-	[ThreadStatic]
-	private static ToolScope? activeScope;
+	// AsyncLocal flows across await continuations, unlike [ThreadStatic] which is bound to a
+	// single thread and would be null if TryGetCompilation ran after an await on a different thread.
+	private static readonly AsyncLocal<ToolScope?> activeScope = new();
 	
 	protected RoslynMcpTool(WorkspaceResolver workspace, FileLogger logger, PaginationCache paginationCache)
 	{
@@ -34,8 +35,8 @@ internal abstract partial class RoslynMcpTool
 	/// </summary>
 	protected ToolScope BeginTool(string name, string? subject = null)
 	{
-		var scope  = new ToolScope(name, subject, logger, () => activeScope = null, paginationCache);
-		activeScope = scope;
+		var scope  = new ToolScope(name, subject, logger, () => activeScope.Value = null, paginationCache);
+		activeScope.Value = scope;
 		
 		return scope;
 	}
@@ -89,12 +90,12 @@ internal abstract partial class RoslynMcpTool
 			
 			compilation = workspace.GetCompilation(projectPath);
 			
-			activeScope?.SetWorkspaceMode(workspace.IsAdhoc(projectPath) is false);
+			activeScope.Value?.SetWorkspaceMode(workspace.IsAdhoc(projectPath) is false);
 			
 			// Annotate when non-obvious resolution occurred.
 			var kind = workspace.GetResolutionKind(projectPath);
 			
-			activeScope?.Record(kind switch {
+			activeScope.Value?.Record(kind switch {
 				
 				ResolutionKind.Directory          => "dir→.csproj",
 				ResolutionKind.FileWalkUp         => "file→.csproj",
@@ -180,12 +181,12 @@ internal abstract partial class RoslynMcpTool
 			
 			project = workspace.GetProject(projectPath);
 			
-			activeScope?.SetWorkspaceMode(workspace.IsAdhoc(projectPath) is false);
+			activeScope.Value?.SetWorkspaceMode(workspace.IsAdhoc(projectPath) is false);
 			
 			// Annotate when non-obvious resolution occurred.
 			var kind = workspace.GetResolutionKind(projectPath);
 			
-			activeScope?.Record(kind switch {
+			activeScope.Value?.Record(kind switch {
 				
 				ResolutionKind.Directory          => "dir→.csproj",
 				ResolutionKind.FileWalkUp         => "file→.csproj",
@@ -336,7 +337,7 @@ internal abstract partial class RoslynMcpTool
 	/// </summary>
 	protected PaginatedResult<T> PaginateAndStore<T>(T[] allResults, ref int skip, int take)
 	{
-		activeScope?.SetCacheTag(hit: false);
+		activeScope.Value?.SetCacheTag(hit: false);
 		
 		var token   = paginationCache.Store(allResults);
 		var page    = Paginate(allResults, ref skip, take);


### PR DESCRIPTION
## Summary
- **Line ending preservation** (item 6, medium): `InsertLinesTool` now detects the file's existing line-ending style (LF vs CRLF) and preserves it, instead of forcing `Environment.NewLine` which silently converted LF files to CRLF on Windows.
- **AsyncLocal scope** (item 11, low): Replaced `[ThreadStatic] activeScope` with `AsyncLocal<ToolScope>` so the scope flows correctly across `await` continuations — prevents silent null dereference if a future tool calls `TryGetCompilation` after an `await`.
- **Backup before editing** (item 12, low): `ReplaceInCodeTool`, `ReplaceInFileTool`, and `InsertLinesTool` now call `BackupStore.Save` before destructive writes, making them recoverable via `roslyn_local_history`.
- **Obsolete TryRestore** (item 8, medium): `BackupStore.TryRestore` is marked `[Obsolete]` with guidance to use the `TryCheck`/`WriteAndInvalidate`/`CompleteRestore` split that routes through `WorkspaceManager`.
- **Token uniqueness** (item 9, medium): Backup tokens now include a random 4-char nonce (`{hash}_{ms}_{nonce}`) to prevent millisecond-collision bugs during pruning. `.bak` filenames and token parsing updated accordingly; legacy 2-part tokens remain parseable.

Closes #145 items 6, 8, 9, 11, 12.

## Test plan
- [ ] Verify clean build (`roslyn_build_project` ✅)
- [ ] `roslyn_insert_lines` on a LF-only file — verify line endings preserved
- [ ] `roslyn_replace_in_file` then `roslyn_local_history action:list` — verify backup appears
- [ ] `roslyn_local_history action:apply` with a new-format token — verify restore works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
