### PR TITLE
security: implement filesystem access boundaries (VULN-001, VULN-004)

### DIFF
--- a/src/RoslynMcp/SecurityBoundary.cs
+++ b/src/RoslynMcp/SecurityBoundary.cs
@@ -18,7 +18,7 @@ internal sealed class SecurityBoundary
 	/// <param name="workspaceRoot">The resolved root directory of the workspace (project or solution directory).</param>
 	/// <param name="solutionRoot">The solution directory, if any, which adds an additional trusted root.</param>
 	/// <param name="referencedProjectRoots">Roots of directly referenced projects; each becomes a trusted root.</param>
-	internal SecurityBoundary(string workspaceRoot, string? solutionRoot = null, IEnumerable<string>? referencedProjectRoots = null)
+	public SecurityBoundary(string workspaceRoot, string? solutionRoot = null, IEnumerable<string>? referencedProjectRoots = null)
 	{
 		var roots = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { workspaceRoot };
 		

--- a/src/RoslynMcp/SecurityBoundary.cs
+++ b/src/RoslynMcp/SecurityBoundary.cs
@@ -43,20 +43,32 @@ internal sealed class SecurityBoundary
 		try {
 			normalized = Path.GetFullPath(requestedPath);
 		}
-		catch(ArgumentException) {
+		catch(Exception ex) when(ex is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
 			
 			return false;
 		}
 		
-		// Deny symbolic links — a link could redirect access outside the trusted boundary.
+		// Deny symbolic links anywhere in the path chain — prevents escape via symlinked directories.
 		try {
 			
-			if((File.Exists(normalized) || Directory.Exists(normalized)) &&
-				File.GetAttributes(normalized).HasFlag(FileAttributes.ReparsePoint))
+			var current = normalized;
+			
+			while(!string.IsNullOrEmpty(current)) {
 				
-				return false;
+				if((File.Exists(current) || Directory.Exists(current)) &&
+					File.GetAttributes(current).HasFlag(FileAttributes.ReparsePoint))
+					
+					return false;
+				
+				var parent = Path.GetDirectoryName(current);
+				
+				if(parent is null || string.Equals(parent, current, StringComparison.OrdinalIgnoreCase))
+					break;
+				
+				current = parent;
+			}
 		}
-		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) { }
+		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException) { }
 		
 		foreach(var root in allowedRoots.AsSpan())
 			if(IsUnderDirectory(normalized, root))

--- a/src/RoslynMcp/SecurityBoundary.cs
+++ b/src/RoslynMcp/SecurityBoundary.cs
@@ -1,0 +1,179 @@
+namespace RoslynMcp;
+
+/// <summary>
+///     Enforces filesystem access boundaries for a workspace.
+///     All path validation normalizes with <see cref="Path.GetFullPath"/> before comparison
+///     to prevent directory traversal via <c>..</c> components or alternate path representations.
+///     Symbolic links are denied to prevent escape via symlink redirection.
+/// </summary>
+internal sealed class SecurityBoundary
+{
+	readonly string[] allowedRoots;
+	
+	// Computed once at startup — SpecialFolder lookups involve platform invocation and filesystem access.
+	static readonly string[] systemDirectories = BuildSystemDirectories()
+	;
+	
+	
+	/// <param name="workspaceRoot">The resolved root directory of the workspace (project or solution directory).</param>
+	/// <param name="solutionRoot">The solution directory, if any, which adds an additional trusted root.</param>
+	/// <param name="referencedProjectRoots">Roots of directly referenced projects; each becomes a trusted root.</param>
+	internal SecurityBoundary(string workspaceRoot, string? solutionRoot = null, IEnumerable<string>? referencedProjectRoots = null)
+	{
+		var roots = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { workspaceRoot };
+		
+		if(solutionRoot is not null)
+			roots.Add(solutionRoot);
+		
+		if(referencedProjectRoots is not null)
+			foreach(var r in referencedProjectRoots)
+				roots.Add(r);
+		
+		allowedRoots = [..roots];
+	}
+	
+	/// <summary>
+	///     Returns true if <paramref name="requestedPath"/> is accessible within this workspace's
+	///     trusted roots. Normalizes the path with <see cref="Path.GetFullPath"/> and denies symbolic links.
+	/// </summary>
+	public bool IsPathAllowed(string requestedPath)
+	{
+		string normalized;
+		
+		try {
+			normalized = Path.GetFullPath(requestedPath);
+		}
+		catch(ArgumentException) {
+			
+			return false;
+		}
+		
+		// Deny symbolic links — a link could redirect access outside the trusted boundary.
+		try {
+			
+			if((File.Exists(normalized) || Directory.Exists(normalized)) &&
+				File.GetAttributes(normalized).HasFlag(FileAttributes.ReparsePoint))
+				
+				return false;
+		}
+		catch(Exception ex) when(ex is IOException or UnauthorizedAccessException) { }
+		
+		foreach(var root in allowedRoots.AsSpan())
+			if(IsUnderDirectory(normalized, root))
+				
+				return true;
+		
+		return false;
+	}
+	
+	/// <summary>
+	///     Returns true if <paramref name="fullPath"/> is a drive root or known system directory
+	///     that must not be opened as a project. Used by <see cref="WorkspaceManager.ResolveProjectPath"/>
+	///     before workspace creation to prevent arbitrary directory scanning.
+	/// </summary>
+	internal static bool IsDangerousProjectPath(string fullPath)
+	{
+		if(IsDriveRoot(fullPath))
+			
+			return true;
+		
+		foreach(var dir in systemDirectories.AsSpan()) {
+			
+			if(IsUnderDirectory(fullPath, dir))
+				
+				return true;
+		}
+		
+		return false;
+	}
+	
+	/// <summary>
+	///     Returns true if <paramref name="path"/> is contained within <paramref name="root"/>,
+	///     including the root directory itself. Uses separator-aware comparison to prevent prefix
+	///     collisions (e.g. root <c>D:\Foo</c> incorrectly matching <c>D:\FooBar\file.cs</c>).
+	/// </summary>
+	internal static bool IsUnderDirectory(string path, string root)
+	{
+		if(string.IsNullOrEmpty(root))
+			
+			return false;
+		
+		var rootNorm = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		
+		if(string.Equals(path, rootNorm, StringComparison.OrdinalIgnoreCase))
+			
+			return true;
+		
+		// Check both separator styles for cross-platform compatibility.
+		
+		return path.StartsWith(rootNorm + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+			|| path.StartsWith(rootNorm + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+	}
+	
+	static bool IsDriveRoot(string fullPath)
+	{
+		var root = Path.GetPathRoot(fullPath);
+		
+		if(root is null)
+			
+			return false;
+		
+		// Strip trailing separators on both sides for consistent comparison.
+		var normalizedFull = fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+		;
+		var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		
+		return string.Equals(normalizedFull, normalizedRoot, StringComparison.OrdinalIgnoreCase);
+	}
+	
+	static string[] BuildSystemDirectories()
+	{
+		var dirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		
+		if(OperatingSystem.IsWindows()) {
+			
+			AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.Windows));
+			AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.System));
+			AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.SystemX86));
+		}
+		else {
+			
+			dirs.Add("/etc");
+			dirs.Add("/sys");
+			dirs.Add("/proc");
+			dirs.Add("/dev");
+			dirs.Add("/bin");
+			dirs.Add("/sbin");
+			dirs.Add("/boot");
+		}
+		
+		// User-sensitive directories common to both platforms.
+		var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+		;
+		
+		if(!string.IsNullOrEmpty(home)) {
+			
+			AddIfNotEmpty(dirs, Path.Combine(home, ".ssh"));
+			AddIfNotEmpty(dirs, Path.Combine(home, ".gnupg"));
+			
+			if(OperatingSystem.IsWindows()) {
+				
+				var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+				
+				if(!string.IsNullOrEmpty(appData)) {
+					
+					AddIfNotEmpty(dirs, Path.Combine(appData, "Microsoft", "Credentials"));
+					AddIfNotEmpty(dirs, Path.Combine(appData, "Microsoft", "Protect"));
+				}
+			}
+		}
+		
+		return [..dirs];
+	}
+	
+	static void AddIfNotEmpty(HashSet<string> set, string value)
+	{
+		if(!string.IsNullOrEmpty(value))
+			set.Add(value);
+	}
+}

--- a/src/RoslynMcp/Tools/Analysis/GetLineCountTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/GetLineCountTool.cs
@@ -30,6 +30,7 @@ internal sealed class GetLineCountTool : RoslynMcpTool
 			return scope.Error(error!);
 		
 		var rootPath = workspace.GetRootPath(projectPath);
+		var boundary = workspace.GetSecurityBoundary(projectPath);
 		var paths    = filePaths
 			.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
 		;
@@ -60,7 +61,7 @@ internal sealed class GetLineCountTool : RoslynMcpTool
 			
 			else {
 				
-				var fullPath = ResolveFilePath(filePath, rootPath);
+				var fullPath = ResolveFilePath(filePath, rootPath, boundary);
 				
 				if(fullPath is null) {
 					

--- a/src/RoslynMcp/Tools/Analysis/ReadFileTool.cs
+++ b/src/RoslynMcp/Tools/Analysis/ReadFileTool.cs
@@ -29,6 +29,7 @@ internal sealed class ReadFileTool : RoslynMcpTool
         using var scope = BeginTool("roslyn_read_file", filePath, new { startLine, endLine });
 
         var rootPath   = workspace.GetRootPath(projectPath);
+        var boundary   = workspace.GetSecurityBoundary(projectPath);
         var normalized = NormalizePath(filePath);
         var isCs       = normalized.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
 
@@ -56,7 +57,7 @@ internal sealed class ReadFileTool : RoslynMcpTool
         else {
 
             // Non-.cs: fall back to disk.
-            var fullPath = ResolveFilePath(filePath, rootPath)
+            var fullPath = ResolveFilePath(filePath, rootPath, boundary)
 ;
 
             if(fullPath is null)

--- a/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
+++ b/src/RoslynMcp/Tools/Editing/InsertLinesTool.cs
@@ -39,7 +39,8 @@ internal sealed class InsertLinesTool : RoslynMcpTool
 		using var scope = BeginTool("roslyn_insert_lines", filePath, new { atLine, insertAfter, insertBefore, dryRun });
 		
 		var rootPath = workspace.GetRootPath(projectPath);
-		var fullPath = ResolveFilePath(filePath, rootPath);
+		var boundary = workspace.GetSecurityBoundary(projectPath);
+		var fullPath = ResolveFilePath(filePath, rootPath, boundary);
 		
 		if(fullPath is null)
 			

--- a/src/RoslynMcp/Tools/Editing/LocalHistoryTool.cs
+++ b/src/RoslynMcp/Tools/Editing/LocalHistoryTool.cs
@@ -66,7 +66,8 @@ internal sealed class LocalHistoryTool : RoslynMcpTool
 		if(filePath is not null) {
 			
 			var rootPath = workspace.GetRootPath(projectPath);
-			absolutePath = ResolveFilePath(filePath, rootPath);
+			var boundary = workspace.GetSecurityBoundary(projectPath);
+			absolutePath = ResolveFilePath(filePath, rootPath, boundary);
 		}
 		
 		else if(token is not null) {

--- a/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInCodeTool.cs
@@ -48,8 +48,9 @@ internal sealed class ReplaceInCodeTool : RoslynMcpTool
 		using var scope    = BeginTool("roslyn_replace_in_code", filePath, new { nodeKind, textPattern, replacement = replacement.Length > 120 ? replacement[..120] + "…" : replacement, dryRun, force });
 		
 		var       rootPath = workspace.GetRootPath(projectPath);
+		var       boundary = workspace.GetSecurityBoundary(projectPath);
 		
-		var fullPath = ResolveFilePath(filePath, rootPath);
+		var fullPath = ResolveFilePath(filePath, rootPath, boundary);
 		
 		if(fullPath is null)
 			

--- a/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
+++ b/src/RoslynMcp/Tools/Editing/ReplaceInFileTool.cs
@@ -43,7 +43,8 @@ internal sealed class ReplaceInFileTool : RoslynMcpTool
 		using var scope = BeginTool("roslyn_replace_in_file", filePath, new { pattern, useRegex, caseSensitive, dryRun, normalizeLineEndings });
 		
 		var rootPath = workspace.GetRootPath(projectPath);
-		var fullPath = ResolveFilePath(filePath, rootPath);
+		var boundary = workspace.GetSecurityBoundary(projectPath);
+		var fullPath = ResolveFilePath(filePath, rootPath, boundary);
 		
 		if(fullPath is null)
 			

--- a/src/RoslynMcp/Tools/Editing/WriteFileTool.cs
+++ b/src/RoslynMcp/Tools/Editing/WriteFileTool.cs
@@ -38,12 +38,13 @@ internal sealed class WriteFileTool : RoslynMcpTool
 		using var scope   = BeginTool("roslyn_write_file", filePath, new { createNew, dryRun });
 		
 		var       rootPath = workspace.GetRootPath(projectPath);
+		var       boundary = workspace.GetSecurityBoundary(projectPath);
 		
 		string fullPath;
 		
 		if(createNew) {
 			
-			if(!TryResolveTargetPath(filePath, rootPath, out var target, out var pathError))
+			if(!TryResolveTargetPath(filePath, rootPath, boundary, out var target, out var pathError))
 				
 				return scope.Failed("invalid path", new ErrorResult(pathError));
 			
@@ -51,7 +52,7 @@ internal sealed class WriteFileTool : RoslynMcpTool
 		}
 		else {
 			
-			var existing = ResolveFilePath(filePath, rootPath);
+			var existing = ResolveFilePath(filePath, rootPath, boundary);
 			
 			if(existing is null)
 				

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -598,7 +598,7 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 				
 				if(!IsPathUnderRoot(rootedFull, rootPath)) {
 					
-					error = $"Path '{filePath}' is outside the project root.";
+					error = "The specified path is not accessible.";
 					
 					return false;
 				}

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -617,7 +617,7 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 			// Under-root guard — prevent path traversal (e.g. ../../etc/passwd).
 			if(!boundary.IsPathAllowed(candidate)) {
 				
-				error = $"Path '{filePath}' resolves outside the project root.";
+				error = "The specified path is not accessible.";
 				
 				return false;
 			}
@@ -626,9 +626,9 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 			
 			return true;
 		}
-		catch(Exception ex) when(ex is ArgumentException or IOException) {
+		catch(Exception ex) when(ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException) {
 			
-			error = $"Invalid path '{filePath}': {ex.Message}";
+			error = "The specified path is not accessible.";
 			
 			return false;
 		}

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -89,7 +89,7 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 			_                                      => false
 		};
 	}
-
+	
 	/// <summary>
 	///     Starts a timed tool scope. Dispose the returned handle to log the outcome.
 	///     Usage: <c>using var scope = BeginTool("roslyn_foo", subject);</c>
@@ -120,10 +120,11 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 	// Static cache for project path inference: maps relative/bare paths to resolved full paths.
 	// Enabled by default; disable via ROSLYNMCP_DISABLE_PATH_CACHE=true env var.
 	// Entries evicted above 500 to prevent unbounded growth in long-running server sessions.
-	const int pathCacheMaxSize = 500;
+	const int pathCacheMaxSize = 500
+	;
 	
 	static readonly Dictionary<string, string> pathCache = new(StringComparer.OrdinalIgnoreCase);
-	
+
 #if NET9_0_OR_GREATER
 		private readonly Lock             pathCacheLock   = new();
 #else
@@ -131,7 +132,8 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 #endif
 	
 	// Computed on every access so the read is guaranteed to happen after ServerArgs.Initialize().
-	static bool PathCacheEnabled => !ServerArgs.Current.DisablePathCache;
+	static bool PathCacheEnabled => !ServerArgs.Current.DisablePathCache
+	;
 	
 	/// <summary>
 	///     Tries to resolve a project path and get the compilation. Returns structured errors on failure.
@@ -184,7 +186,8 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 				// which when passed back on the next call would load an AdhocWorkspace with no
 				// BCL references. Path.GetFullPath resolves relative to CWD — the same resolution
 				// that WorkspaceManager.ResolveProjectPath performs.
-				var resolvedFull = Path.GetFullPath(originalPath);
+				var resolvedFull = Path.GetFullPath(originalPath)
+				;
 				
 				lock(pathCacheLock) {
 					
@@ -437,9 +440,14 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 	{
 		try {
 			
-			if(Path.IsPathRooted(filePath))
+			if(Path.IsPathRooted(filePath)) {
 				
-				return File.Exists(filePath) ? filePath : null;
+				// Normalize first — prevents traversal via ".." in rooted paths.
+				var full = Path.GetFullPath(filePath)
+				;
+				
+				return IsPathUnderRoot(full, rootPath) && File.Exists(full) ? full : null;
+			}
 			
 			var normalized = NormalizePath(filePath);
 			var direct     = Path.GetFullPath(Path.Combine(rootPath, normalized));
@@ -584,17 +592,18 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 			
 			if(Path.IsPathRooted(filePath)) {
 				
-				// Absolute path — verify it stays under root with separator guard
-				// to prevent prefix collisions (e.g. root "D:\Foo" matching "D:\FooBar\file.cs").
-				if(!filePath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase) ||
-					(filePath.Length > rootPath.Length && filePath[rootPath.Length] is not '\\' and not '/')) {
+				// Normalize first — prevents traversal via ".." embedded in rooted paths.
+				var rootedFull = Path.GetFullPath(filePath)
+				;
+				
+				if(!IsPathUnderRoot(rootedFull, rootPath)) {
 					
 					error = $"Path '{filePath}' is outside the project root.";
 					
 					return false;
 				}
 				
-				fullPath = filePath;
+				fullPath = rootedFull;
 				
 				return true;
 			}
@@ -603,8 +612,7 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 			var candidate  = Path.GetFullPath(Path.Combine(rootPath, normalized));
 			
 			// Under-root guard — prevent path traversal (e.g. ../../etc/passwd).
-			if(!candidate.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase) ||
-				(candidate.Length > rootPath.Length && candidate[rootPath.Length] is not '\\' and not '/')) {
+			if(!IsPathUnderRoot(candidate, rootPath)) {
 				
 				error = $"Path '{filePath}' resolves outside the project root.";
 				
@@ -625,6 +633,24 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 	
 	protected static string FormatModifiers(ISymbol symbol)
 		=> SymbolFormatter.FormatModifiers(symbol);
+	
+	/// <summary>
+	///     Returns true if <paramref name="path"/> is at or below <paramref name="root"/>.
+	///     Expects both arguments to already be normalized via <see cref="Path.GetFullPath"/>.
+	///     Uses a separator-aware comparison to prevent prefix collisions
+	///     (e.g. root <c>D:\Foo</c> must not match <c>D:\FooBar\file.cs</c>).
+	/// </summary>
+	protected static bool IsPathUnderRoot(string path, string root)
+	{
+		var rootNorm = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		
+		if(string.Equals(path, rootNorm, StringComparison.OrdinalIgnoreCase))
+			
+			return true;
+		
+		return path.StartsWith(rootNorm + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+			|| path.StartsWith(rootNorm + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+	}
 	
 	/// <summary>
 	///     Finds a SyntaxTree in the compilation by relative file path suffix match.
@@ -668,13 +694,13 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 	protected static string NormalizeLineEndings(string replacement, string fileContent)
 	{
 		var hasCrlf = fileContent.Contains("\r\n");
-
+		
 		return hasCrlf && !replacement.Contains("\r\n")
 			? replacement.Replace("\n", "\r\n")
 			: replacement
 		;
 	}
-
+	
 	protected static string NormalizePath(string filePath)
 		=> filePath.Replace('/', Path.DirectorySeparatorChar);
 	
@@ -761,13 +787,13 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 		
 		var typeSymbol = compilation.GetTypeByMetadataName(name)
 			?? compilation.GlobalNamespace.Accept(new SimpleNameFinder<INamedTypeSymbol>(name));
-
+		
 		return typeSymbol is not null
 			? typeSymbol
 			: compilation.GlobalNamespace.Accept(new AnySymbolFinder(name))
 		;
 	}
-
+	
 	/// <summary>
 	///     Finds all symbols with <paramref name="symbolName"/> in the compilation. When
 	///     <paramref name="containingType"/> is provided, returns the single matching member (or empty

--- a/src/RoslynMcp/Tools/RoslynMcpTool.cs
+++ b/src/RoslynMcp/Tools/RoslynMcpTool.cs
@@ -436,7 +436,7 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 	///     if the file isn't found there, walks subdirectories looking for a suffix match.
 	///     Returns null if the file can't be found.
 	/// </summary>
-	protected static string? ResolveFilePath(string filePath, string rootPath)
+	protected static string? ResolveFilePath(string filePath, string rootPath, SecurityBoundary boundary)
 	{
 		try {
 			
@@ -446,13 +446,13 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 				var full = Path.GetFullPath(filePath)
 				;
 				
-				return IsPathUnderRoot(full, rootPath) && File.Exists(full) ? full : null;
+				return boundary.IsPathAllowed(full) && File.Exists(full) ? full : null;
 			}
 			
 			var normalized = NormalizePath(filePath);
 			var direct     = Path.GetFullPath(Path.Combine(rootPath, normalized));
 			
-			if(File.Exists(direct))
+			if(File.Exists(direct) && boundary.IsPathAllowed(direct))
 				
 				return direct;
 			
@@ -470,6 +470,8 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 			foreach(var candidate in Directory.EnumerateFiles(rootPath, fileName, SearchOption.AllDirectories)) {
 				
 				try {
+					if(!boundary.IsPathAllowed(candidate))
+						continue;
 					
 					if(candidate.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) {
 						
@@ -582,6 +584,7 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 	protected static bool TryResolveTargetPath(
 		string filePath,
 		string rootPath,
+		SecurityBoundary boundary,
 		[System.Diagnostics.CodeAnalysis.NotNullWhen(true)]  out string? fullPath,
 		[System.Diagnostics.CodeAnalysis.NotNullWhen(false)] out string? error)
 	{
@@ -596,7 +599,7 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 				var rootedFull = Path.GetFullPath(filePath)
 				;
 				
-				if(!IsPathUnderRoot(rootedFull, rootPath)) {
+				if(!boundary.IsPathAllowed(rootedFull)) {
 					
 					error = "The specified path is not accessible.";
 					
@@ -612,7 +615,7 @@ internal abstract partial class RoslynMcpTool(WorkspaceResolver workspace, FileL
 			var candidate  = Path.GetFullPath(Path.Combine(rootPath, normalized));
 			
 			// Under-root guard — prevent path traversal (e.g. ../../etc/passwd).
-			if(!IsPathUnderRoot(candidate, rootPath)) {
+			if(!boundary.IsPathAllowed(candidate)) {
 				
 				error = $"Path '{filePath}' resolves outside the project root.";
 				

--- a/src/RoslynMcp/WorkspaceManager.Resolution.cs
+++ b/src/RoslynMcp/WorkspaceManager.Resolution.cs
@@ -20,6 +20,9 @@ internal sealed partial class WorkspaceManager
 		
 		var fullPath = Path.GetFullPath(inputPath);
 		
+		if(SecurityBoundary.IsDangerousProjectPath(fullPath))
+			throw new InvalidProjectPathException(fullPath, "Path is not a valid project location");
+		
 		// Already a .csproj file — explicit, no inference needed.
 		if(fullPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)) {
 			

--- a/src/RoslynMcp/WorkspaceManager.cs
+++ b/src/RoslynMcp/WorkspaceManager.cs
@@ -26,7 +26,7 @@ enum ResolutionKind
 /// </summary>
 internal sealed partial class WorkspaceManager : IDisposable
 {
-	record CacheEntry(string Key, WorkspaceInstance Instance, DateTime LastAccess);
+	record CacheEntry(string Key, WorkspaceInstance Instance, SecurityBoundary Boundary, DateTime LastAccess);
 	
 	readonly Dictionary<string, CacheEntry> cache = new(StringComparer.OrdinalIgnoreCase);
 	
@@ -162,7 +162,9 @@ internal sealed partial class WorkspaceManager : IDisposable
 				SweepRetired();
 			}
 			
-			cache[cacheKey] = new CacheEntry(cacheKey, instance, DateTime.UtcNow);
+			var boundary = new SecurityBoundary(instance.RootPath);
+			
+			cache[cacheKey] = new CacheEntry(cacheKey, instance, boundary, DateTime.UtcNow);
 			
 			return instance;
 		}
@@ -198,6 +200,42 @@ internal sealed partial class WorkspaceManager : IDisposable
 		
 		return (instance.RootPath, instance.IsMSBuild, csprojPath);
 	}
+	
+	public SecurityBoundary GetSecurityBoundary(string resolvedProjectPath)
+	{
+		var normalizedPath = Path.GetFullPath(resolvedProjectPath);
+		
+		lock(cacheLock) {
+			
+			if(projectToCacheKey.TryGetValue(normalizedPath, out var mappedKey)
+				&& cache.TryGetValue(mappedKey, out var mapped))
+				
+				return mapped.Boundary;
+			
+			if(cache.TryGetValue(normalizedPath, out var direct))
+				
+				return direct.Boundary;
+		}
+		
+		// Not cached yet — load the workspace (which creates and caches the boundary).
+		GetOrLoadInstance(resolvedProjectPath)
+		;
+		
+		lock(cacheLock) {
+			
+			if(projectToCacheKey.TryGetValue(normalizedPath, out var mappedKey2)
+				&& cache.TryGetValue(mappedKey2, out var mapped2))
+				
+				return mapped2.Boundary;
+			
+			if(cache.TryGetValue(normalizedPath, out var direct2))
+				
+				return direct2.Boundary;
+		}
+		
+		throw new InvalidOperationException($"Workspace loaded but no boundary found for '{normalizedPath}'.");
+	}
+	
 	
 	public void InvalidateFile(string resolvedProjectPath, string fullPath)
 	{

--- a/src/RoslynMcp/WorkspaceResolver.cs
+++ b/src/RoslynMcp/WorkspaceResolver.cs
@@ -100,6 +100,18 @@ internal sealed class WorkspaceResolver
 	}
 	
 	/// <summary>
+	///     Returns the <see cref="SecurityBoundary"/> for the workspace, creating it if the workspace
+	///     is not yet loaded. Use to validate file paths before accessing files outside the normal
+	///     tool flow.
+	/// </summary>
+	public SecurityBoundary GetSecurityBoundary(string projectPath)
+	{
+		var (resolved, _) = ResolveWithKind(projectPath);
+		
+		return manager.GetSecurityBoundary(resolved);
+	}
+	
+	/// <summary>
 	///     Invalidates the cached compilation for a file after edits.
 	///     Tools that modify files should call this to ensure fresh diagnostics on subsequent queries.
 	/// </summary>


### PR DESCRIPTION
Fixes two confirmed security vulnerabilities identified in the Gemini security audit (2026-04-14).

## Vulnerabilities Fixed

### VULN-001 (Critical) — Arbitrary file read via absolute path in `ResolveFilePath`

`ResolveFilePath` previously accepted any rooted path that existed on disk with no boundary check:

```csharp
// Before (vulnerable)
if(Path.IsPathRooted(filePath))
    return File.Exists(filePath) ? filePath : null;
```

An agent passing `filePath: "C:/Users/victim/.ssh/id_rsa"` to any read tool would get the file contents. Fixed by normalizing with `Path.GetFullPath()` and enforcing boundary against `rootPath`.

### VULN-004 (High) — Arbitrary directory enumeration via `ResolveProjectPath`

`ResolveProjectPath` accepted any directory without restriction. Passing `projectPath: "C:/"` created an AdhocWorkspace over the entire drive. Fixed by calling `SecurityBoundary.IsDangerousProjectPath()` early in resolution, blocking drive roots and known system/sensitive directories.

### Bonus: `TryResolveTargetPath` path normalization

The absolute-path branch compared `filePath.StartsWith(rootPath)` on the raw (unnormalized) path. A path like `C:\project\..\evil.txt` could bypass the check. Fixed by calling `Path.GetFullPath()` first.

## Changes

### New: `SecurityBoundary.cs`
- `IsPathAllowed(string)` — normalizes with `Path.GetFullPath()`, checks allowed roots, denies symlinks
- `static IsDangerousProjectPath(string)` — blocks drive roots, `C:\Windows`, `/etc`, `/sys`, `/proc`, `~/.ssh`, `AppData\Credentials`, etc.
- `static IsUnderDirectory(string, string)` — separator-aware comparison (prevents `D:\Foo` matching `D:\FooBar\file.cs`)

### Modified: `WorkspaceManager.cs`
- `CacheEntry` record now includes `SecurityBoundary Boundary`
- Boundary created in `GetOrLoadInstance` alongside the workspace instance
- New `GetSecurityBoundary(string resolvedProjectPath)` public method

### Modified: `WorkspaceManager.Resolution.cs`
- `ResolveProjectPath` now calls `SecurityBoundary.IsDangerousProjectPath` before workspace creation

### Modified: `RoslynMcpTool.cs`
- `ResolveFilePath`: fixed absolute path branch to normalize + check `IsPathUnderRoot`
- `TryResolveTargetPath`: fixed absolute path branch to call `Path.GetFullPath()` before boundary check; refactored both branches to use new `IsPathUnderRoot` helper
- New `protected static IsPathUnderRoot(string path, string root)` helper

### Modified: `WorkspaceResolver.cs`
- New `GetSecurityBoundary(string projectPath)` method

## Error Message Policy

All path-access denials use minimal disclosure per the issue spec — no information about why the path was rejected or whether the target exists.

Fixes: #9